### PR TITLE
Fixes to PciRegs tests

### DIFF
--- a/GrpPciRegisters/allPciRegs_r10b.cpp
+++ b/GrpPciRegisters/allPciRegs_r10b.cpp
@@ -88,19 +88,24 @@ AllPciRegs_r10b::RunCoreTest()
      * 1) none
      *  \endverbatim
      */
+    bool result = true;
+
     if (gCtrlrConfig->SetState(ST_DISABLE_COMPLETELY) == false)
         throw FrmwkEx(HERE);
 
-    ValidateDefaultValues();
-    ValidateROBitsAfterWriting();
+    result &= ValidateDefaultValues();
+    result &= ValidateROBitsAfterWriting();
+    if (!result) 
+    	throw FrmwkEx(HERE, "Test failed, check log for specific bit errors.");
 }
 
 
-void
+bool
 AllPciRegs_r10b::ValidateDefaultValues()
 {
     const PciSpcType *pciMetrics = gRegisters->GetPciMetrics();
     const vector<PciCapabilities> *pciCap = gRegisters->GetPciCapabilities();
+    bool result = true;
 
     LOG_NRM("Validating default register values");
 
@@ -108,12 +113,10 @@ AllPciRegs_r10b::ValidateDefaultValues()
     for (int j = 0; j < PCISPC_FENCE; j++) {
         if (pciMetrics[j].specRev != mSpecRev)
             continue;
-
         // PCI hdr registers don't have an assoc capability
         if (pciMetrics[j].cap == PCICAP_FENCE)
-            ValidatePciHdrRegisterROAttribute((PciSpc)j);
+            result &= ValidatePciHdrRegisterROAttribute((PciSpc)j);
     }
-
     // Traverse all discovered capabilities
     for (size_t i = 0; i < pciCap->size(); i++) {
         // Read all registers assoc with the discovered capability
@@ -121,19 +124,22 @@ AllPciRegs_r10b::ValidateDefaultValues()
             if (pciMetrics[j].specRev != SPECREV_10b)
                 continue;
             else if (pciCap->at(i) == pciMetrics[j].cap)
-                ValidatePciCapRegisterROAttribute((PciSpc)j);
+                result &= ValidatePciCapRegisterROAttribute((PciSpc)j);
         }
     }
+    return result;
 }
 
 
-void
+bool
 AllPciRegs_r10b::ValidateROBitsAfterWriting()
 {
+    uint32_t tmpValue;
     uint64_t value;
     uint64_t origValue;
     const PciSpcType *pciMetrics = gRegisters->GetPciMetrics();
     const vector<PciCapabilities> *pciCap = gRegisters->GetPciCapabilities();
+    bool result = true;
 
     LOG_NRM("Validating RO bits after writing");
 
@@ -154,13 +160,13 @@ AllPciRegs_r10b::ValidateROBitsAfterWriting()
             value = (origValue | pciMetrics[j].maskRO);
             if (gRegisters->Write((PciSpc)j, value) == false)
                 throw FrmwkEx(HERE);
-            ValidatePciHdrRegisterROAttribute((PciSpc)j);
+            result &= ValidatePciHdrRegisterROAttribute((PciSpc)j);
 
             LOG_NRM("Validate RO attribute after trying to write 0");
             value = (origValue & ~pciMetrics[j].maskRO);
             if (gRegisters->Write((PciSpc)j, value) == false)
                 throw FrmwkEx(HERE);
-            ValidatePciHdrRegisterROAttribute((PciSpc)j);
+            result &= ValidatePciHdrRegisterROAttribute((PciSpc)j);
         }
     }
 
@@ -177,35 +183,88 @@ AllPciRegs_r10b::ValidateROBitsAfterWriting()
 
             if (pciCap->at(i) == pciMetrics[j].cap) {
                 LOG_NRM("Validate RO attribute after trying to write 1");
-                if (gRegisters->Read((PciSpc)j, origValue) == false)
-                    throw FrmwkEx(HERE);
+        	if (pciMetrics[j].size > MAX_SUPPORTED_REG_SIZE) {
+		    origValue = 0;
+		    LOG_NRM("Reading %s",pciMetrics[j].desc);
+		    for (uint32_t k = 0; (k*DWORD_LEN) < pciMetrics[j].size; k++) {
+		    	if (gRegisters->Read(NVMEIO_PCI_HDR, DWORD_LEN, pciMetrics[j].offset + (k * DWORD_LEN),
+			    (uint8_t *)&tmpValue) == false) {
+				throw FrmwkEx(HERE);
+			}
+			origValue |= (tmpValue << (k * DWORD_LEN * 8));
+		    }
+		    LOG_NRM("Value = 0x%016lX",(long unsigned int)origValue);
+		} else {    
+		    if (gRegisters->Read((PciSpc)j, origValue) == false)
+                    	throw FrmwkEx(HERE);
+		}	
                 value = (origValue | pciMetrics[j].maskRO);
-                if (gRegisters->Write((PciSpc)j, value) == false)
-                    throw FrmwkEx(HERE);
-                ValidatePciCapRegisterROAttribute((PciSpc)j);
+		if (pciMetrics[j].size > MAX_SUPPORTED_REG_SIZE) {
+		    tmpValue = 0;
+		    LOG_NRM("Writing %s",pciMetrics[j].desc);
+		    for (uint32_t k=0; (k*DWORD_LEN) < pciMetrics[j].size; k++) {
+		    	tmpValue = (value >> ( k*DWORD_LEN*8 )) & 0xFFFFFFFF;
+		    	if (gRegisters->Write(NVMEIO_PCI_HDR, DWORD_LEN, pciMetrics[j].offset + (k * DWORD_LEN),
+			    (uint8_t *)&tmpValue) == false)
+			  	throw FrmwkEx(HERE);
+		    }
+		    LOG_NRM("Value = 0x%016lX",(long unsigned int)value);
+		} else {
+                    if (gRegisters->Write((PciSpc)j, value) == false)
+	          	throw FrmwkEx(HERE);
+		}
+                result &= ValidatePciCapRegisterROAttribute((PciSpc)j);
 
                 LOG_NRM("Validate RO attribute after trying to write 0");
+
+        	if (pciMetrics[j].size > MAX_SUPPORTED_REG_SIZE) {
+		    origValue = 0;
+		    LOG_NRM("Reading %s",pciMetrics[j].desc);
+		    for (uint32_t k = 0; (k*DWORD_LEN) < pciMetrics[j].size; k++) {
+		    	if (gRegisters->Read(NVMEIO_PCI_HDR, DWORD_LEN, pciMetrics[j].offset + (k * DWORD_LEN),
+			    (uint8_t *)&tmpValue) == false) {
+				throw FrmwkEx(HERE);
+			}
+			origValue |= (tmpValue << (k * DWORD_LEN * 8));
+		    }
+		    LOG_NRM("Value = 0x%016lX",(long unsigned int)origValue);
+		} else {    
+		    if (gRegisters->Read((PciSpc)j, origValue) == false)
+                    	throw FrmwkEx(HERE);
+		}	
                 value = (origValue & ~pciMetrics[j].maskRO);
-                if (gRegisters->Write((PciSpc)j, value) == false)
-                    throw FrmwkEx(HERE);
-                ValidatePciCapRegisterROAttribute((PciSpc)j);
+		if (pciMetrics[j].size > MAX_SUPPORTED_REG_SIZE) {
+		    tmpValue = 0;
+		    LOG_NRM("Writing %s",pciMetrics[j].desc);
+		    for (uint32_t k=0; (k*DWORD_LEN) < pciMetrics[j].size; k++) {
+		    	tmpValue = (value >> ( k*DWORD_LEN*8 )) & 0xFFFFFFFF;
+		    	if (gRegisters->Write(NVMEIO_PCI_HDR, DWORD_LEN, pciMetrics[j].offset + (k * DWORD_LEN),
+			    (uint8_t *)&tmpValue) == false)
+			  	throw FrmwkEx(HERE);
+		    }
+		    LOG_NRM("Value = 0x%016lX",(long unsigned int)value);
+		} else {
+                    if (gRegisters->Write((PciSpc)j, value) == false)
+	          	throw FrmwkEx(HERE);
+		}
+                result &= ValidatePciCapRegisterROAttribute((PciSpc)j);
             }
         }
     }
+    return result;
 }
 
 
-void
+bool
 AllPciRegs_r10b::ValidatePciCapRegisterROAttribute(PciSpc reg)
 {
     uint64_t value;
     uint64_t expectedValue;
     const PciSpcType *pciMetrics = gRegisters->GetPciMetrics();
-
+    bool result = true;
 
     if (pciMetrics[reg].size > MAX_SUPPORTED_REG_SIZE) {
         for (uint32_t k = 0; (k*DWORD_LEN) < pciMetrics[reg].size; k++) {
-
             if (gRegisters->Read(NVMEIO_PCI_HDR, DWORD_LEN,
                 pciMetrics[reg].offset + (k * DWORD_LEN),
                 (uint8_t *)&value) == false) {
@@ -225,9 +284,10 @@ AllPciRegs_r10b::ValidatePciCapRegisterROAttribute(PciSpc reg)
                     pciMetrics[reg].maskRO);
 
                 if (value != expectedValue) {
-                    throw FrmwkEx(HERE, "%s RO bit #%d has incorrect value",
+                    LOG_NRM ("%s RO bit #%d has incorrect value",
                         pciMetrics[reg].desc,
                         ReportOffendingBitPos(value, expectedValue));
+		    result = false;
                 }
             }
         }
@@ -247,20 +307,22 @@ AllPciRegs_r10b::ValidatePciCapRegisterROAttribute(PciSpc reg)
             pciMetrics[reg].maskRO);
 
         if (value != expectedValue) {
-            throw FrmwkEx(HERE, 
-                "%s RO bit #%d has incorrect value", pciMetrics[reg].desc,
+            LOG_NRM ("%s RO bit #%d has incorrect value", pciMetrics[reg].desc,
                 ReportOffendingBitPos(value, expectedValue));
+	    result = false;
         }
     }
+    return result;
 }
 
 
-void
+bool
 AllPciRegs_r10b::ValidatePciHdrRegisterROAttribute(PciSpc reg)
 {
     uint64_t value;
     uint64_t expectedValue;
     const PciSpcType *pciMetrics = gRegisters->GetPciMetrics();
+    bool result = true;
 
     if (pciMetrics[reg].size > MAX_SUPPORTED_REG_SIZE) {
         for (int k = 0; (k*sizeof(value)) < pciMetrics[reg].size; k++) {
@@ -290,25 +352,26 @@ AllPciRegs_r10b::ValidatePciHdrRegisterROAttribute(PciSpc reg)
 
                     if (cmdReg & CMD_IOSE) {
                         if (value != expectedValue) {
-                            throw FrmwkEx(HERE,
-                                "%s RO bit #%d has incorrect value",
+                            LOG_NRM ("%s RO bit #%d has incorrect value",
                                 pciMetrics[reg].desc,
                                 ReportOffendingBitPos(value, expectedValue));
+			    result = false;
                         }
                     } else {  // Optional index/Data pair register not supported
                         expectedValue = 0;
                         if (value != expectedValue) {
-                            throw FrmwkEx(HERE,
-                                "%s RO bit #%d has incorrect value",
+			    LOG_NRM ("%s RO bit #%d has incorrect value",
                                 pciMetrics[reg].desc,
                                 ReportOffendingBitPos(value, expectedValue));
+			    result = false;
                         }
                     }
                 } else {    // generically handled all other registers
                     if (value != expectedValue) {
-                        throw FrmwkEx(HERE, "%s RO bit #%d has incorrect value",
+                        LOG_NRM ("%s RO bit #%d has incorrect value",
                             pciMetrics[reg].desc,
                             ReportOffendingBitPos(value, expectedValue));
+			result = false;
                     }
                 }
             }
@@ -334,26 +397,30 @@ AllPciRegs_r10b::ValidatePciHdrRegisterROAttribute(PciSpc reg)
 
             if (cmdReg & CMD_IOSE) {
                 if (value != expectedValue) {
-                    throw FrmwkEx(HERE, "%s RO bit #%d has incorrect value",
+		    LOG_NRM ("%s RO bit #%d has incorrect value",
                         pciMetrics[reg].desc,
                         ReportOffendingBitPos(value, expectedValue));
+		    result = false;
                 }
             } else {    // Optional index/Data pair register not supported
                 expectedValue = 0;
                 if (value != expectedValue) {
-                    throw FrmwkEx(HERE, "%s RO bit #%d has incorrect value",
+                    LOG_NRM ("%s RO bit #%d has incorrect value",
                         pciMetrics[reg].desc,
                         ReportOffendingBitPos(value, expectedValue));
+		    result = false;
                 }
             }
         } else {    // generically handled all other registers
             if (value != expectedValue) {
-                throw FrmwkEx(HERE, "%s RO bit #%d has incorrect value",
+                LOG_NRM ("%s RO bit #%d has incorrect value",
                     pciMetrics[reg].desc,
                     ReportOffendingBitPos(value, expectedValue));
+		result = false;
             }
         }
     }
+    return result;
 }
 
 }   // namespace

--- a/GrpPciRegisters/allPciRegs_r10b.h
+++ b/GrpPciRegisters/allPciRegs_r10b.h
@@ -57,30 +57,30 @@ private:
      * Validate the specified PCI hdr register RO bits report correct values if
      * and only if they are not vendor specific.
      * @param reg Pass the register to validate
-     * @return returns upon success, otherwise throws exception
+     * @return true upon success, otherwise false
      */
-    void ValidatePciHdrRegisterROAttribute(PciSpc reg);
+    bool ValidatePciHdrRegisterROAttribute(PciSpc reg);
 
     /**
      * Validate the specified capabilities registers' RO bits report correct
      * values if and only if they are not vendor specific.
      * @param reg Pass the register to validate
-     * @return returns upon success, otherwise throws exception
+     * @return true upon success, otherwise false
      */
-    void ValidatePciCapRegisterROAttribute(PciSpc reg);
+    bool ValidatePciCapRegisterROAttribute(PciSpc reg);
 
     /**
      * Validate all the registers have default values being reported for
      * the RO bits which are not vendor specific.
-     * @return returns upon success, otherwise throws exception
+     * @return true upon success, otherwise false
      */
-    void ValidateDefaultValues();
+    bool ValidateDefaultValues();
 
     /**
      * Validate all the registers hare RO after attempting to write to them.
-     * @return returns upon success, otherwise throws exception
+     * @return true upon success, otherwise false.
      */
-    void ValidateROBitsAfterWriting();
+    bool ValidateROBitsAfterWriting();
 };
 
 }   // namespace

--- a/Singletons/registers.cpp
+++ b/Singletons/registers.cpp
@@ -482,15 +482,15 @@ Registers::DiscoverPciCapabilities()
         return;
     }
     LOG_NRM("Reading extended PCI space offset 0x%04X=0x%08X", io.offset,
-        (uint16_t)REGMASK(nextCap, 4));
+        (uint32_t)REGMASK(nextCap, 4));
     capId = (uint16_t)REGMASK(nextCap, 2);
     capOffset = (uint16_t)REGMASK((nextCap >> 20), 2);
-    if (nextCap == 0) {
+    if (capId == 0) {
         LOG_NRM("No extended PCI capabilities supported");
     } else if (capId == 0x0001) {
         LOG_NRM("Decoding AERCAP capabilities");
         mPciCap.push_back(PCICAP_AERCAP);
-        mPciSpcMetrics[PCISPC_AERID].offset = capOffset;
+        mPciSpcMetrics[PCISPC_AERID].offset = io.offset;
         for (int i = PCISPC_AERUCES; i <= PCISPC_AERTLP; i++) {
             mPciSpcMetrics[i].offset =
                 mPciSpcMetrics[i-1].offset + mPciSpcMetrics[i-1].size;

--- a/Utils/fileSystem.cpp
+++ b/Utils/fileSystem.cpp
@@ -121,7 +121,7 @@ FileSystem::RotateDumpDir()
 
     // Rename all files to "*.prev"
     for (size_t i = 0; i < allFiles.size(); i++) {
-        string newName = (allFiles[i].filename() + ".prev");
+        //string newName = (allFiles[i].filename() + ".prev");
         snprintf(work, sizeof(work), "mv %s%s %s%s.prev",
             dumpDir.c_str(), allFiles[i].filename().c_str(),
             dumpDir.c_str(), allFiles[i].filename().c_str());


### PR DESCRIPTION
Singletons\registers.cpp was not setting extended capabilities offsets
correctly ('off by one'), this is fixed.
GrpPciRegisters\allPciRegs_r10b was not handeling larger than Dword
registers correctly, this is fixed.
GrpPciRegisters\allPciRegs_r10b enhancement, test now runs to completion
and then throws exception on failure, instead of throw exception on
first failure.  All failures are logged LOG_NRM.

one last, Util/fileSystem.cpp.. I forgot I changed that, I commented out the one line it was preventing me from building and didn't seem to be important.

Thanks,
Ivan
