### PR TITLE
SetFeatures Test fix, Flush Tet Fix, WriteRead Combo Test fix, compiler warnings fix

### DIFF
--- a/GrpAdminSetGetFeatCombo/fidArbitration_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidArbitration_r10b.cpp
@@ -134,7 +134,7 @@ FIDArbitration_r10b::RunCoreTest()
     setFeaturesCmd->SetFID(BaseFeatures::FID_ARBITRATION);
 
     uint8_t arbBurst[] =  {
-        1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, NO_LIMIT
+        0, 1, 2, 3, 4, 5, 6,  NO_LIMIT
     };
     uint64_t arbSize = sizeof(arbBurst) / sizeof(arbBurst[0]);
 

--- a/GrpNVMFlushCmd/functionalityBare_r10b.cpp
+++ b/GrpNVMFlushCmd/functionalityBare_r10b.cpp
@@ -155,6 +155,12 @@ FunctionalityBare_r10b::RunCoreTest()
         flushCmd->SetNSID(bare[i]);
         for (uint64_t nWrBlks = 0; nWrBlks < (ncap - 1); nWrBlks += maxWrBlks) {
             LOG_NRM("Sending #%ld blks of #%ld", nWrBlks, (ncap -1));
+            if ((nWrBlks + maxWrBlks) >= ncap) {
+                maxWrBlks = ncap - nWrBlks;
+                LOG_NRM("Resize max write blocks to #%ld", maxWrBlks);
+                ResizeDataBuf(readCmd, writeCmd, namSpcPtr, maxWrBlks,
+                    prpBitmask);
+            }            
             for (uint64_t nLBA = 0; nLBA < maxWrBlks; nLBA++) {
                 writeMem->SetDataPattern(dataPat[nLBA % dpArrSize],
                     (nWrBlks + nLBA + 1), (nLBA * lbaDataSize), lbaDataSize);
@@ -200,6 +206,42 @@ SharedMemBufferPtr wrPayload)
             "Data read from media miscompared from written");
         throw FrmwkEx(HERE, "Data miscompare");
     }
+}
+
+void
+FunctionalityBare_r10b::ResizeDataBuf(SharedReadPtr &readCmd,
+    SharedWritePtr &writeCmd, ConstSharedIdentifyPtr namSpcPtr,
+    uint64_t maxWrBlks, send_64b_bitmask prpBitmask)
+{
+    LBAFormat lbaFormat = namSpcPtr->GetLBAFormat();
+    uint64_t lbaDataSize = (1 << lbaFormat.LBADS);
+
+    SharedMemBufferPtr readMem = readCmd->GetRWPrpBuffer();
+    SharedMemBufferPtr writeMem = writeCmd->GetRWPrpBuffer();
+
+    switch (gInformative->IdentifyNamespace(namSpcPtr)) {
+    case Informative::NS_BARE:
+    case Informative::NS_METAS:
+        LOG_NRM("Resized max rd/wr blks to %ld for separate meta or bare", maxWrBlks);
+        writeMem->Init(maxWrBlks * lbaDataSize);
+        readMem->Init(maxWrBlks * lbaDataSize);
+        break;
+    case Informative::NS_METAI:
+        LOG_NRM("Resized max rd/wr blks to %ld for integrated meta", maxWrBlks);
+        writeMem->Init(maxWrBlks * (lbaDataSize + lbaFormat.MS));
+        readMem->Init(maxWrBlks * (lbaDataSize + lbaFormat.MS));
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+    throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+    break;
+    }
+
+    writeCmd->SetPrpBuffer(prpBitmask, writeMem);
+    writeCmd->SetNLB(maxWrBlks - 1); // 0 based value.
+
+    readCmd->SetPrpBuffer(prpBitmask, readMem);
+    readCmd->SetNLB(maxWrBlks - 1); // 0 based value.
 }
 
 

--- a/GrpNVMFlushCmd/functionalityBare_r10b.h
+++ b/GrpNVMFlushCmd/functionalityBare_r10b.h
@@ -20,7 +20,7 @@
 #include "test.h"
 #include "../Cmds/write.h"
 #include "../Cmds/read.h"
-
+#include "../Cmds/identify.h"
 
 namespace GrpNVMFlushCmd {
 
@@ -57,6 +57,9 @@ private:
     // Adding a member variable? Then edit the copy constructor and operator=().
     ///////////////////////////////////////////////////////////////////////////
     void VerifyDataPat(SharedReadPtr readCmd, SharedMemBufferPtr wrPayload);
+    void ResizeDataBuf(SharedReadPtr &readCmd, SharedWritePtr &writeCmd,
+        ConstSharedIdentifyPtr namSpcPtr, uint64_t maxWrBlks,
+        send_64b_bitmask prpBitmask);    
 };
 
 }   // namespace

--- a/GrpNVMWriteReadCombo/startingLBABare_r10b.h
+++ b/GrpNVMWriteReadCombo/startingLBABare_r10b.h
@@ -19,6 +19,8 @@
 
 #include "test.h"
 #include "../Cmds/read.h"
+#include "../Cmds/write.h"
+#include "../Cmds/identify.h"
 
 namespace GrpNVMWriteReadCombo {
 
@@ -55,6 +57,9 @@ private:
     // Adding a member variable? Then edit the copy constructor and operator=().
     ///////////////////////////////////////////////////////////////////////////
     void VerifyDataPat(SharedReadPtr readCmd, SharedMemBufferPtr wrPayload);
+    void ResizeDataBuf(SharedReadPtr &readCmd, SharedWritePtr &writeCmd,
+        ConstSharedIdentifyPtr namSpcPtr, uint64_t maxWrBlks,
+        send_64b_bitmask prpBitmask);    
 };
 
 }   // namespace

--- a/Singletons/metaRsrc.cpp
+++ b/Singletons/metaRsrc.cpp
@@ -159,7 +159,6 @@ MetaRsrc::ReleaseMetaBuf(MetaDataBuf metaBuf)
 void
 MetaRsrc::FreeAllMetaBuf()
 {
-    int rc;
     deque<MetaDataBuf>::iterator resIter = mMetaReserved.begin();
 
     // Search the ordered elements, moves every reserved item into released
@@ -180,7 +179,7 @@ MetaRsrc::FreeAllMetaBuf()
         // been deleted by a prior NVME_IOCTL_DEVICE_STATE call to dnvme. The
         // act of not freeing causes memory leak, the act of freeing to many
         // times is of no harm.
-        rc = ioctl(mFd, NVME_IOCTL_METABUF_DELETE, tmp.ID);
+        ioctl(mFd, NVME_IOCTL_METABUF_DELETE, tmp.ID);
     }
 
     mMetaAllocSize = 0;

--- a/tnvme.cpp
+++ b/tnvme.cpp
@@ -708,7 +708,6 @@ ExecuteTests(struct CmdLine &cl, vector<Group *> &groups)
     int numGrps = 0;
     bool allTestsPass = true;    // assuming success until we find otherwise
     bool allHaveRun = false;
-    bool thisTestPass;
     TestRef targetTst;
     TestSetType testsToRun;
     bool tstSetOK;
@@ -768,7 +767,6 @@ ExecuteTests(struct CmdLine &cl, vector<Group *> &groups)
 
             numGrps++;
             while (allHaveRun == false) {
-                thisTestPass = true;
 
                 switch (groups[iGrp]->RunTest(testsToRun, tstIdx,
                     cl.skiptest, skipped, cl.preserve, failedTests,
@@ -778,7 +776,6 @@ ExecuteTests(struct CmdLine &cl, vector<Group *> &groups)
                     break;
                 case Group::TR_FAIL:
                     allTestsPass = false;
-                    thisTestPass = false;
                     numFailed++;
                     numSkipped += skipped;
                     if (cl.ignore) {


### PR DESCRIPTION
GrpAdminSetGetFeatCombo/fidArbitration_r10b.cpp: fixed arbitration burst values, should be n from 2^n not x from x=2^n.
GrpNVMFlushCmd/functionalityBare_r10b.cpp:  fixed end of namespace size check, so test doesn't run over the end (copied from meta namespace range check, and updated appropriately)
GrpNVMWriteReadCombo/startingLBABare_r10b.cpp: also end of namespace size check wasn't in bare namespace check, but was in meta namespace check (copied over, and updated appropriately)

Singletons/metaRsrc.cpp:  compiler warning, rc set but not used. comment says return value is ignored.
tnvme.cpp: compiler warning, thisTestPass set but not used.

I hope I didn't get any tabs in there this time :)  
