### PR TITLE
make clean

### DIFF
--- a/Cmds/Makefile
+++ b/Cmds/Makefile
@@ -57,7 +57,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/Exception/Makefile
+++ b/Exception/Makefile
@@ -33,7 +33,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminAsyncCmd/Makefile
+++ b/GrpAdminAsyncCmd/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminCreateIOCQCmd/Makefile
+++ b/GrpAdminCreateIOCQCmd/Makefile
@@ -37,7 +37,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminCreateIOQCmd/Makefile
+++ b/GrpAdminCreateIOQCmd/Makefile
@@ -39,7 +39,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminCreateIOSQCmd/Makefile
+++ b/GrpAdminCreateIOSQCmd/Makefile
@@ -39,7 +39,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminDeleteIOCQCmd/Makefile
+++ b/GrpAdminDeleteIOCQCmd/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminDeleteIOSQCmd/Makefile
+++ b/GrpAdminDeleteIOSQCmd/Makefile
@@ -36,7 +36,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminGetFeatCmd/Makefile
+++ b/GrpAdminGetFeatCmd/Makefile
@@ -36,7 +36,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminGetLogPgCmd/Makefile
+++ b/GrpAdminGetLogPgCmd/Makefile
@@ -43,7 +43,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminIdentifyCmd/Makefile
+++ b/GrpAdminIdentifyCmd/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminSetFeatCmd/Makefile
+++ b/GrpAdminSetFeatCmd/Makefile
@@ -34,7 +34,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpAdminSetGetFeatCombo/Makefile
+++ b/GrpAdminSetGetFeatCombo/Makefile
@@ -42,7 +42,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpBasicInit/Makefile
+++ b/GrpBasicInit/Makefile
@@ -42,7 +42,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpCtrlRegisters/Makefile
+++ b/GrpCtrlRegisters/Makefile
@@ -35,7 +35,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpGeneralCmds/Makefile
+++ b/GrpGeneralCmds/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpInterrupts/Makefile
+++ b/GrpInterrupts/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMCompareCmd/Makefile
+++ b/GrpNVMCompareCmd/Makefile
@@ -33,7 +33,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMDatasetMgmtCmd/Makefile
+++ b/GrpNVMDatasetMgmtCmd/Makefile
@@ -39,7 +39,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMFlushCmd/Makefile
+++ b/GrpNVMFlushCmd/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMFlushCmd/functionalityMeta_r10b.cpp
+++ b/GrpNVMFlushCmd/functionalityMeta_r10b.cpp
@@ -206,7 +206,7 @@ FunctionalityMeta_r10b::RunCoreTest()
 
         flushCmd->SetNSID(meta[i]);
 
-        for (uint64_t sLBA = 0; sLBA < (ncap - 1); sLBA += maxWrBlks) {
+        for (uint64_t sLBA = 0; sLBA < maxWrBlks/*(ncap - 1)*/; sLBA += maxWrBlks) {
             LOG_NRM("Processing at #%ld blk of %ld", sLBA, (ncap -1));
             if ((sLBA + maxWrBlks) >= ncap) {
                 maxWrBlks = ncap - sLBA;

--- a/GrpNVMReadCmd/Makefile
+++ b/GrpNVMReadCmd/Makefile
@@ -44,7 +44,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMWriteCmd/Makefile
+++ b/GrpNVMWriteCmd/Makefile
@@ -44,7 +44,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMWriteReadCombo/Makefile
+++ b/GrpNVMWriteReadCombo/Makefile
@@ -44,7 +44,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpNVMWriteUncorrectCmd/Makefile
+++ b/GrpNVMWriteUncorrectCmd/Makefile
@@ -33,7 +33,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpPciRegisters/Makefile
+++ b/GrpPciRegisters/Makefile
@@ -34,7 +34,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpQueues/Makefile
+++ b/GrpQueues/Makefile
@@ -49,7 +49,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpResets/Makefile
+++ b/GrpResets/Makefile
@@ -35,7 +35,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/GrpTemplate/Makefile
+++ b/GrpTemplate/Makefile
@@ -34,7 +34,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/Queues/Makefile
+++ b/Queues/Makefile
@@ -41,7 +41,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/Singletons/Makefile
+++ b/Singletons/Makefile
@@ -39,7 +39,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)

--- a/Utils/Makefile
+++ b/Utils/Makefile
@@ -38,7 +38,7 @@ $(OUT): $(OBJ)
 	ar rcs $(OUT) $(OBJ)
 
 clean:
-	rm -f $(OBJ) Makefile.bak
+	rm -f $(OBJ) $(OUT) Makefile.bak
 
 clobber: clean
 	rm -f $(OUT)


### PR DESCRIPTION
Each folder generates a static library file (*.a) on build.  Running `make clean` would not remove this file.  Fixed so that each makefile removes all files it generates in a build.
