### PR TITLE
Fix reservation failure tests

### DIFF
--- a/Cmds/identifyDefs.h
+++ b/Cmds/identifyDefs.h
@@ -445,6 +445,13 @@ typedef enum OACSBits {
     OACS_SUP_NSMANAGEMENT_CMD = 0x0008
 } OACSBits;
 
+///Bit definitions for IDCTRLRCAP_MIO
+typedef enum MICBits{
+	MIC_SUP_PCI_PORTS 		= 0x0001,
+	MIC_SUP_CONTROLLERS 	= 0x0002,
+	MIC_SUP_SRIOV			= 0x0004
+}MICBits;
+
 typedef enum FRMWBits {
     FRMW_SLOT1_RO   = 0x01,
     FRMW_NUM_SLOTS  = 0x0e,

--- a/GrpReservationsHostA/registerReservation.cpp
+++ b/GrpReservationsHostA/registerReservation.cpp
@@ -191,7 +191,8 @@ RegisterReservation::RunCoreTest()
     retStat = IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq, reservationRegisterCmd, "Register Key 0xAE HostA", true, CESTAT_SUCCESS);
 
 
-	//LOG_NRM("Try to register (not replace) a new key. Should always fail even with IEKEY=1 and same key as before... Expecting Rsvr Conflict.");
+	LOG_NRM("Try to register (not replace) the same key. expecting pass");
+
 	// Same command as before...
 	/*
 	reservationRegisterCmd->SetNSID(1);
@@ -201,8 +202,17 @@ RegisterReservation::RunCoreTest()
 	writeRegKey->InitAlignment(16, true, 0xAE); // 0xAF's as arbitrary new key
 	reservationRegisterCmd->SetPrpBuffer(prpBitmask, writeRegKey);
 	*/
-    //retStat = IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq, reservationRegisterCmd, "Register Key 0xAE HostA", true, CESTAT_RSRV_CONFLICT);
+    retStat = IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq, reservationRegisterCmd, "Register Key 0xAE HostA", true, CESTAT_SUCCESS);
 
+	LOG_NRM("Try to register (not replace) a new key. Should always fail even with IEKEY=1 ... Expecting Rsvr Conflict.");
+	reservationRegisterCmd->SetNSID(1);
+	reservationRegisterCmd->SetCPTPL(0); // No PTPL change
+	reservationRegisterCmd->SetIEKEY(1);
+	reservationRegisterCmd->SetRREGA(0); // Register Key
+	writeRegKey->Init(16, true, 0xAA); 
+	reservationRegisterCmd->SetPrpBuffer(prpBitmask, writeRegKey);
+
+    retStat = IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq, reservationRegisterCmd, "Register Key 0xAE HostA", true, CESTAT_RSRV_CONFLICT);
     LOG_NRM("Completed RegisterReservation::RunCoreTest")
 }
 

--- a/GrpReservationsHostB/createResources_r11.cpp
+++ b/GrpReservationsHostB/createResources_r11.cpp
@@ -87,11 +87,21 @@ CreateResources_r11::RunnableCoreTest(bool preserve)
 
     ConstSharedIdentifyPtr idCtrlrCap = gInformative->GetIdentifyCmdCtrlr();
     uint64_t oncs = idCtrlrCap->GetValue(IDCTRLRCAP_ONCS);
-    if ((oncs & ONCS_SUP_RSRV) == 0) {
-        LOG_NRM("Reporting Reservations not supported (oncs)%ld", oncs);
+    uint64_t mic = idCtrlrCap->GetValue(IDCTRLRCAP_MIC);
+    if((mic & MIC_SUP_PCI_PORTS) == 0)
+    {
+        LOG_NRM("Reporting only one PCI port is supported (mic)%ld", mic);
         return RUN_FALSE;
     }
+    else
+    {
+        if ((oncs & ONCS_SUP_RSRV) == 0)
+        {
+            LOG_NRM("Reporting Reservations not supported (oncs)%ld", oncs);
+            return RUN_FALSE;
+        }
 
+    }
     preserve = preserve;    // Suppress compiler error/warning
     return RUN_TRUE;        // This test is never destructive
 }

--- a/GrpReservationsHostB/readWriteToUnacquiredReservation.cpp
+++ b/GrpReservationsHostB/readWriteToUnacquiredReservation.cpp
@@ -87,9 +87,19 @@ ReadWriteToUnacquiredReservation::RunnableCoreTest(bool preserve)
 
     ConstSharedIdentifyPtr idCtrlrCap = gInformative->GetIdentifyCmdCtrlr();
     uint64_t oncs = idCtrlrCap->GetValue(IDCTRLRCAP_ONCS);
-    if ((oncs & ONCS_SUP_RSRV) == 0) {
-        LOG_NRM("Reporting Reservations not supported (oncs)%ld", oncs);
+    uint64_t mic = idCtrlrCap->GetValue(IDCTRLRCAP_MIC);
+    if((mic & MIC_SUP_PCI_PORTS) == 0)
+    {
+        LOG_NRM("Reporting only one PCI port is supported (mic)%ld", mic);
         return RUN_FALSE;
+    }
+    else
+    {
+        if ((oncs & ONCS_SUP_RSRV) == 0)
+        {
+            LOG_NRM("Reporting Reservations not supported (oncs)%ld", oncs);
+            return RUN_FALSE;
+        }
     }
     preserve = preserve;    // Suppress compiler error/warning
     return RUN_TRUE;        // This test is never destructive

--- a/GrpReservationsHostB/registerReservation.cpp
+++ b/GrpReservationsHostB/registerReservation.cpp
@@ -89,9 +89,19 @@ RegisterReservation::RunnableCoreTest(bool preserve)
 
     ConstSharedIdentifyPtr idCtrlrCap = gInformative->GetIdentifyCmdCtrlr();
     uint64_t oncs = idCtrlrCap->GetValue(IDCTRLRCAP_ONCS);
-    if ((oncs & ONCS_SUP_RSRV) == 0) {
-        LOG_NRM("Reporting Reservations not supported (oncs)%ld", oncs);
+    uint64_t mic = idCtrlrCap->GetValue(IDCTRLRCAP_MIC);
+    if((mic & MIC_SUP_PCI_PORTS) == 0)
+    {
+        LOG_NRM("Reporting only one PCI port is supported (mic)%ld", mic);
         return RUN_FALSE;
+    }
+    else
+    {
+        if ((oncs & ONCS_SUP_RSRV) == 0)
+        {
+            LOG_NRM("Reporting Reservations not supported (oncs)%ld", oncs);
+            return RUN_FALSE;
+        }
     }
     preserve = preserve;    // Suppress compiler error/warning
     return RUN_TRUE;        // This test is never destructive


### PR DESCRIPTION
Fix explanation: #1
Spec:
From NVMe spec (1.1a, 1.2): A host that is a registrant of a namespace may register the same reservation key value multiple times with the namespace on the same or different controllers. It is an error for a host that is already a registrant of a namespace to register with the same namespace using a different registration key value (i.e., the command is aborted with status Reservation Conflict).
Test expectation:
This test expects firmware to abort the command with status “Reservation Conflict” when host tries to register with the same key again.
Change:
RegisterReservation.cpp file is corrected to expect success when the same key is sent.
Fix explanation: #2
GrpReservationHostB tests need to check whether DUT supports multiple ports before starting the test
