### PR TITLE
Created new files for PSDT handling with spec 1.2

### DIFF
--- a/GrpAdminAsyncCmd/Makefile
+++ b/GrpAdminAsyncCmd/Makefile
@@ -20,6 +20,7 @@ SRC =					\
 	grpAdminAsyncCmd.cpp		\
   unsupportRsvdFields_r10b.cpp	\
   unsupportRsvdFields_r11b.cpp	\
+  unsupportRsvdFields_r12.cpp	\
 	abortByReset_r10b.cpp		\
 	verifyMaxEvents_r10b.cpp	\
 	verifyMasking_r10b.cpp		\

--- a/GrpAdminAsyncCmd/grpAdminAsyncCmd.cpp
+++ b/GrpAdminAsyncCmd/grpAdminAsyncCmd.cpp
@@ -17,6 +17,7 @@
 #include "grpAdminAsyncCmd.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "abortByReset_r10b.h"
 #include "verifyMaxEvents_r10b.h"
 #include "verifyMasking_r10b.h"
@@ -40,7 +41,6 @@ GrpAdminAsyncCmd::GrpAdminAsyncCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(VerifyMasking_r10b, GrpAdminAsyncCmd)
         APPEND_TEST_AT_XLEVEL(VerifyEventQueueing_r10b, GrpAdminAsyncCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(UnsupportRsvdFields_r11b, GrpAdminAsyncCmd)
         APPEND_TEST_AT_XLEVEL(AbortByReset_r10b, GrpAdminAsyncCmd)
@@ -48,7 +48,14 @@ GrpAdminAsyncCmd::GrpAdminAsyncCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(VerifyMasking_r10b, GrpAdminAsyncCmd)
         APPEND_TEST_AT_XLEVEL(VerifyEventQueueing_r10b, GrpAdminAsyncCmd)
         break;
-        
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(UnsupportRsvdFields_r12, GrpAdminAsyncCmd)
+        APPEND_TEST_AT_XLEVEL(AbortByReset_r10b, GrpAdminAsyncCmd)
+        APPEND_TEST_AT_XLEVEL(VerifyMaxEvents_r10b, GrpAdminAsyncCmd)
+        APPEND_TEST_AT_XLEVEL(VerifyMasking_r10b, GrpAdminAsyncCmd)
+        APPEND_TEST_AT_XLEVEL(VerifyEventQueueing_r10b, GrpAdminAsyncCmd)
+        break;  
+      
     default:
     case SPECREVTYPE_FENCE:
         throw FrmwkEx(HERE, "Object created with an unknown SpecRev=%d",

--- a/GrpAdminAsyncCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminAsyncCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+#include <boost/format.hpp>
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Utils/kernelAPI.h"
+#include "../Utils/irq.h"
+#include "../Utils/io.h"
+#include "../Cmds/asyncEventReq.h"
+#include "../Cmds/asyncEventReqDefs.h"
+#include "../Cmds/getLogPage.h"
+
+
+#define SQ0TBDL     0x1000
+
+
+namespace GrpAdminAsyncCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.2");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Reset ctrlr to cause a clearing of DUT state. Issue 1 async cmd. "
+        "Delay 5 sec, verify no CE exists in ACQ. Ring doorbell for IOSQ # 1, "
+        "reap a successful CE from the ASQ, validate CE.DW0 for proper error. "
+        "Read error event log page to clear async event. Unsupported DW's and "
+        "rsvd fields are treated identical, the recipient is not required to "
+        "check their value. Receipt of reserved coded values shall be reported "
+        "as an error. Issue same cmd setting all unsupported/rsvd fields, "
+        "expect success. Set: DW0_b14:10, DW2, DW3, DW4, DW5, DW6, DW7, DW8, "
+        "DW9, DW10, DW11, DW12, DW13, DW14, DW15. Validate CE.DW0 for ringing "
+        "non-existent doorbell. Read error event log page to clear "
+        "async event.");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    return ((preserve == true) ? RUN_FALSE : RUN_TRUE);   // Test is destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) none
+     *  \endverbatim
+     */
+    if (gCtrlrConfig->SetState(ST_DISABLE_COMPLETELY) == false)
+        throw FrmwkEx(HERE);
+
+    LOG_NRM("Create admin queues ACQ and ASQ for test lifetime");
+    SharedACQPtr acq = SharedACQPtr(new ACQ(gDutFd));
+    acq->Init(5);
+
+    SharedASQPtr asq = SharedASQPtr(new ASQ(gDutFd));
+    asq->Init(5);
+
+    // All queues will use identical IRQ vector
+    IRQ::SetAnySchemeSpecifyNum(1);
+
+    gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    if (gCtrlrConfig->SetState(ST_ENABLE) == false)
+        throw FrmwkEx(HERE);
+
+    // Test async events without setting the rsvd bits in the cmd.
+    TestAsyncEvents(acq, asq, false);
+
+    // Test async events by setting the rsvd bits in the cmd.
+    TestAsyncEvents(acq, asq, true);
+
+}
+
+
+void
+UnsupportRsvdFields_r12::TestAsyncEvents(SharedACQPtr &acq, SharedASQPtr &asq,
+    bool rsvd)
+{
+    uint32_t isrCount;
+    uint32_t ceRemain;
+    uint32_t numReaped;
+    uint32_t numCE;
+
+    SendAsyncEventRequests(asq, 1, rsvd);
+
+    sleep(5);
+    if (acq->ReapInquiryWaitSpecify(CALC_TIMEOUT_ms(1), 1, numCE, isrCount)
+        == true) {
+        acq->Dump(FileSystem::PrepDumpFile(mGrpName, mTestName, "acq.fail1"),
+            "Dump Entire ACQ");
+        throw FrmwkEx(HERE, "0 CE's expected in ACQ but found %d CE's", numCE);
+    }
+
+    InvalidSQWriteDoorbell();
+    sleep(1);
+    if (acq->ReapInquiryWaitSpecify(CALC_TIMEOUT_ms(1), 1, numCE, isrCount)
+        == false) {
+        acq->Dump(FileSystem::PrepDumpFile(mGrpName, mTestName, "acq.fail2"),
+            "Dump Entire ACQ");
+        throw FrmwkEx(HERE, "1 CE expected in ACQ but found %d CE's", numCE);
+    }
+
+    SharedMemBufferPtr ceMem = SharedMemBufferPtr(new MemBuffer());
+    if ((numReaped = acq->Reap(ceRemain, ceMem, isrCount, numCE, true)) != 1) {
+        acq->Dump(FileSystem::PrepDumpFile(mGrpName, mTestName, "acq.fail3"),
+            "Dump Entire ACQ");
+        throw FrmwkEx(HERE, "Unable to reap on ACQ");
+    }
+
+    union CE *ce = (union CE *)ceMem->GetBuffer();
+
+    if (ce->n.async.asyncEventType != EVENT_TYPE_ERROR_STS) {
+        throw FrmwkEx(HERE, "Invalid async event error status, "
+            "(Expected : Received) :: (%d : %d)", EVENT_TYPE_ERROR_STS,
+            ce->n.async.asyncEventType);
+    } else if (ce->n.async.asyncEventInfo != ERR_STS_INVALID_SQ) {
+        throw FrmwkEx(HERE, "Invalid async event info, "
+            "(Expected : Received) :: (%d : %d)", ERR_STS_INVALID_SQ,
+            ce->n.async.asyncEventInfo);
+    }
+    LOG_NRM("Associated Log page = %d", ce->n.async.assocLogPage);
+
+    ReadLogPage(acq, asq, ce->n.async.assocLogPage);
+}
+
+
+void
+UnsupportRsvdFields_r12::SendAsyncEventRequests(SharedASQPtr &asq,
+    uint32_t nCmds, bool rsvd)
+{
+    uint16_t uniqueId;
+    string work;
+
+    LOG_NRM("Create aync event request cmd");
+    SharedAsyncEventReqPtr asyncEventReqCmd =
+        SharedAsyncEventReqPtr(new AsyncEventReq());
+
+    if (rsvd == true) {
+        LOG_NRM("Set all cmd's rsvd bits");
+        uint32_t work = asyncEventReqCmd->GetDword(0);
+        work |= 0x00003c00;      // Set DW0_b13:10 bits
+        asyncEventReqCmd->SetDword(work, 0);
+
+        for (uint32_t dw = 2; dw <= 15; dw++)
+            asyncEventReqCmd->SetDword(0xffffffff, dw);
+    } else {
+        LOG_NRM("Reserved bits in the cmd are not set");
+    }
+
+    for (uint32_t i = 0; i < nCmds; i++) {
+        LOG_NRM("Send the async event request cmd to hdw via ASQ");
+        asq->Send(asyncEventReqCmd, uniqueId);
+        work = str(boost::format("asyncEventReq.%d") % i);
+        asq->Dump(FileSystem::PrepDumpFile(mGrpName, mTestName,
+            "asq", work), "Before doorbell ring");
+        asq->Ring();
+    }
+}
+
+
+void
+UnsupportRsvdFields_r12::InvalidSQWriteDoorbell()
+{
+    uint64_t value;
+    if (gRegisters->Read((CtlSpc)CTLSPC_CAP, value) == false)
+        throw FrmwkEx(HERE);
+
+    value &= CAP_DSTRD;
+    uint32_t capDstrd = value >> 32;
+    uint32_t sq1Doorbell = SQ0TBDL + (2 * 4 << capDstrd);
+    LOG_NRM("SQ 1 doorbell in controller space = 0x%X", sq1Doorbell);
+
+    value = 0x1;
+    if (gRegisters->Write(NVMEIO_BAR01, sizeof(uint32_t), sq1Doorbell,
+        (uint8_t *)&value) == false)
+          throw FrmwkEx(HERE);
+}
+
+
+void
+UnsupportRsvdFields_r12::ReadLogPage(SharedACQPtr &acq, SharedASQPtr &asq,
+    uint8_t logId)
+{
+    string work;
+
+    LOG_NRM("Reading log page with LID = %d to clear the event mask", logId);
+    ConstSharedIdentifyPtr idCtrlrStruct = gInformative->GetIdentifyCmdCtrlr();
+    uint16_t elpeVal = idCtrlrStruct->GetValue(IDCTRLRCAP_ELPE) + 1;
+    LOG_NRM("Identify controller ELPE = %d (1-based)", elpeVal);
+
+    uint16_t totalBytes = elpeVal * GetLogPage::ERRINFO_DATA_SIZE;
+    LOG_NRM("Total bytes available for error info log page: %d", totalBytes);
+    uint8_t mps;
+    if (!gCtrlrConfig->GetMPS(mps))
+        throw FrmwkEx(HERE, "Failed to retrieve CC.MPS value");
+    uint32_t twoPages = 2 * (1 << (mps + 12));
+    LOG_NRM("Size of two memory pages (i.e. PRP1 & PRP2): %d bytes", twoPages);
+    // PRP2 cannot be pointer to PRP list, so don't ask for more than 2 pages
+    if (totalBytes > twoPages) {
+        LOG_NRM("Can only utilize two memory pages; reducing total bytes");
+        totalBytes = twoPages;
+    }
+    uint16_t totalDwords = totalBytes / 4;
+
+    LOG_NRM("Create get log page cmd and assoc some buffer memory");
+    SharedGetLogPagePtr getLogPgCmd = SharedGetLogPagePtr(new GetLogPage());
+
+    LOG_NRM("Create memory buffer for log page to request error information");
+    SharedMemBufferPtr getLogPageMem = SharedMemBufferPtr(new MemBuffer());
+    send_64b_bitmask prpReq =
+        (send_64b_bitmask)(MASK_PRP1_PAGE | MASK_PRP2_PAGE);
+
+    LOG_NRM("Get log page to request error information logId = %d", logId);
+    getLogPgCmd->SetLID(logId);
+    getLogPageMem->Init(totalBytes, true);
+    getLogPgCmd->SetPrpBuffer(prpReq, getLogPageMem);
+    getLogPgCmd->SetNUMD(totalDwords - 1); //0-based
+
+    work = str(boost::format("ErrorLog%d") % (uint32_t)logId);
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        getLogPgCmd, work, true);
+}
+
+
+}   // namespace
+

--- a/GrpAdminAsyncCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminAsyncCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Queues/acq.h"
+#include "../Queues/asq.h"
+
+namespace GrpAdminAsyncCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    void SendAsyncEventRequests(SharedASQPtr &asq, uint32_t nCmds, bool rsvd);
+    void InvalidSQWriteDoorbell();
+    void ReadLogPage(SharedACQPtr &acq, SharedASQPtr &asq, uint8_t logId);
+    void TestAsyncEvents(SharedACQPtr &acq, SharedASQPtr &asq, bool rsvd);
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminCreateIOCQCmd/Makefile
+++ b/GrpAdminCreateIOCQCmd/Makefile
@@ -21,6 +21,7 @@ SRC =					\
 	createResources_r10b.cpp	\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
+	unsupportRsvdFields_r12.cpp	\
 	invalidQID_r10b.cpp		\
 	maxQSizeExceed_r10b.cpp
 

--- a/GrpAdminCreateIOCQCmd/grpAdminCreateIOCQCmd.cpp
+++ b/GrpAdminCreateIOCQCmd/grpAdminCreateIOCQCmd.cpp
@@ -19,6 +19,7 @@
 #include "createResources_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "invalidQID_r10b.h"
 #include "maxQSizeExceed_r10b.h"
 
@@ -39,10 +40,15 @@ GrpAdminCreateIOCQCmd::GrpAdminCreateIOCQCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminCreateIOCQCmd)
         APPEND_TEST_AT_XLEVEL(MaxQSizeExceed_r10b, GrpAdminCreateIOCQCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminCreateIOCQCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpAdminCreateIOCQCmd)
+        APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminCreateIOCQCmd)
+        APPEND_TEST_AT_XLEVEL(MaxQSizeExceed_r10b, GrpAdminCreateIOCQCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminCreateIOCQCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminCreateIOCQCmd)
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminCreateIOCQCmd)
         APPEND_TEST_AT_XLEVEL(MaxQSizeExceed_r10b, GrpAdminCreateIOCQCmd)
         break;

--- a/GrpAdminCreateIOCQCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminCreateIOCQCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Utils/queues.h"
+#include "../Utils/io.h"
+
+namespace GrpAdminCreateIOCQCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.3");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Find 1st bare namspc, or find 1st meta namspc, or find 1st E2E "
+        "namspc. Unsupported DW's and rsvd fields are treated identical, the "
+        "recipient is not required to check their value. Receipt of reserved "
+        "coded values shall be reported as an error. Issue a CreateIOCQ cmd "
+        "with QID=1, num elements=2, but set all unsupported/rsvd fields, "
+        "expect success. Set: DW0_b14:10, DW2, DW3, DW4, DW5, DW6, DW7, "
+        "DW11_b15:2, DW12, DW13, DW14, DW15. Then issue a CreateIOSQ cmd to "
+        "assoc, QID=1, num elements = 2. Issue a write cmd sending 1 block and "
+        "approp supporting meta/E2E if necessary to the selected namspc at "
+        "LBA 0, data pattern of word++, read back, verify pattern.");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if ((preserve == false) && gCmdLine.rsvdfields)
+        return RUN_TRUE;
+    return RUN_FALSE;    // Optional test skipped or is destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+    uint64_t maxIOQEntries = 2;
+
+    // Lookup objs which were created in a prior test within group
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Setup element sizes for the IOQ's");
+    uint8_t iocqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_CQES) & 0xf);
+    uint8_t iosqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_SQES) & 0xf);
+    gCtrlrConfig->SetIOCQES(iocqes);
+    gCtrlrConfig->SetIOSQES(iosqes);
+
+    LOG_NRM("Create IOCQ");
+    SharedIOCQPtr iocq = SharedIOCQPtr(new IOCQ(gDutFd));
+
+    LOG_NRM("Allocate contiguous memory; IOCQ has ID=%d", IOQ_ID);
+    iocq->Init(IOQ_ID, maxIOQEntries, true, 0);
+
+    LOG_NRM("Form a Create IOCQ cmd to perform queue creation");
+    SharedCreateIOCQPtr createIOCQCmd = SharedCreateIOCQPtr(new CreateIOCQ());
+    createIOCQCmd->Init(iocq);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = createIOCQCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    createIOCQCmd->SetDword(work, 0);
+
+    createIOCQCmd->SetDword(0xffffffff, 2);
+    createIOCQCmd->SetDword(0xffffffff, 3);
+    createIOCQCmd->SetDword(0xffffffff, 4);
+    createIOCQCmd->SetDword(0xffffffff, 5);
+    createIOCQCmd->SetDword(0xffffffff, 6);
+    createIOCQCmd->SetDword(0xffffffff, 7);
+
+    // DW11_b15:2
+    work = createIOCQCmd->GetDword(11);
+    work |= 0x0000fffc;
+    createIOCQCmd->SetDword(work, 11);
+
+    createIOCQCmd->SetDword(0xffffffff, 12);
+    createIOCQCmd->SetDword(0xffffffff, 13);
+    createIOCQCmd->SetDword(0xffffffff, 14);
+    createIOCQCmd->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        createIOCQCmd, "", true);
+
+    LOG_NRM("Create the assoc IOSQ");
+    SharedIOSQPtr iosq = Queues::CreateIOSQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, IOQ_ID, 0);
+
+    WriteReadVerify(iosq, iocq);
+}
+
+
+void
+UnsupportRsvdFields_r12::WriteReadVerify(SharedIOSQPtr iosq,
+    SharedIOCQPtr iocq)
+{
+    Informative::Namspc namspcData = gInformative->Get1stBareMetaE2E();
+    LBAFormat lbaFormat = namspcData.idCmdNamspc->GetLBAFormat();
+    uint64_t lbaDataSize = namspcData.idCmdNamspc->GetLBADataSize();
+
+    SharedWritePtr writeCmd = SharedWritePtr(new Write());
+    SharedMemBufferPtr writeMem = SharedMemBufferPtr(new MemBuffer());
+
+    SharedReadPtr readCmd = SharedReadPtr(new Read());
+    SharedMemBufferPtr readMem = SharedMemBufferPtr(new MemBuffer());
+
+    send_64b_bitmask prpBitmask = (send_64b_bitmask)
+        (MASK_PRP1_PAGE | MASK_PRP2_PAGE | MASK_PRP2_LIST);
+
+    switch (namspcData.type) {
+    case Informative::NS_BARE:
+        writeMem->Init(lbaDataSize);
+        readMem->Init(lbaDataSize);
+        break;
+    case Informative::NS_METAS:
+        writeMem->Init(lbaDataSize);
+        readMem->Init(lbaDataSize);
+        if (gRsrcMngr->SetMetaAllocSize(lbaFormat.MS) == false)
+            throw FrmwkEx(HERE);
+        writeCmd->AllocMetaBuffer();
+        readCmd->AllocMetaBuffer();
+        break;
+    case Informative::NS_METAI:
+        writeMem->Init(lbaDataSize + lbaFormat.MS);
+        readMem->Init(lbaDataSize + lbaFormat.MS);
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+        throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+        break;
+    }
+
+    writeCmd->SetPrpBuffer(prpBitmask, writeMem);
+    writeCmd->SetNSID(namspcData.id);
+    writeCmd->SetNLB(0);
+
+    readCmd->SetPrpBuffer(prpBitmask, readMem);
+    readCmd->SetNSID(namspcData.id);
+    readCmd->SetNLB(0);
+
+    switch (namspcData.type) {
+    case Informative::NS_BARE:
+        writeMem->SetDataPattern(DATAPAT_INC_32BIT);
+        break;
+    case Informative::NS_METAS:
+        writeMem->SetDataPattern(DATAPAT_INC_32BIT);
+        writeCmd->SetMetaDataPattern(DATAPAT_INC_32BIT);
+        break;
+    case Informative::NS_METAI:
+        writeMem->SetDataPattern(DATAPAT_INC_32BIT);
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+        throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+        break;
+    }
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+        iocq, writeCmd, "", true);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+        iocq, readCmd, "", true);
+
+    VerifyDataPat(readCmd, writeCmd);
+}
+
+
+void
+UnsupportRsvdFields_r12::VerifyDataPat(SharedReadPtr readCmd,
+    SharedWritePtr writeCmd)
+{
+    LOG_NRM("Compare read vs written data to verify");
+    SharedMemBufferPtr rdPayload = readCmd->GetRWPrpBuffer();
+    SharedMemBufferPtr wrPayload = writeCmd->GetRWPrpBuffer();
+    if (rdPayload->Compare(wrPayload) == false) {
+        readCmd->Dump(
+            FileSystem::PrepDumpFile(mGrpName, mTestName, "ReadCmd"),
+            "Read command");
+        writeCmd->Dump(
+            FileSystem::PrepDumpFile(mGrpName, mTestName, "WriteCmd"),
+            "Write command");
+        throw FrmwkEx(HERE, "Data miscompare");
+    }
+
+    // If meta data is allocated then compare meta data.
+    if (writeCmd->GetMetaBuffer() != NULL) {
+        const uint8_t *metaRdBuff = readCmd->GetMetaBuffer();
+        const uint8_t *metaWrBuff = writeCmd->GetMetaBuffer();
+        if (memcmp(metaRdBuff, metaWrBuff, writeCmd->GetMetaBufferSize())) {
+            readCmd->Dump(
+                FileSystem::PrepDumpFile(mGrpName, mTestName, "ReadCmdMeta"),
+                "Read command with meta data");
+            writeCmd->Dump(
+                FileSystem::PrepDumpFile(mGrpName, mTestName, "WriteCmdMeta"),
+                "Write command with meta data");
+            throw FrmwkEx(HERE, "Meta data miscompare");
+        }
+    }
+}
+
+
+}   // namespace
+

--- a/GrpAdminCreateIOCQCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminCreateIOCQCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Queues/iocq.h"
+#include "../Queues/iosq.h"
+#include "../Cmds/read.h"
+#include "../Cmds/write.h"
+
+namespace GrpAdminCreateIOCQCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    void WriteReadVerify(SharedIOSQPtr iosq, SharedIOCQPtr iocq);
+    void VerifyDataPat(SharedReadPtr readCmd, SharedWritePtr writeCmd);
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminCreateIOSQCmd/Makefile
+++ b/GrpAdminCreateIOSQCmd/Makefile
@@ -21,6 +21,7 @@ SRC =					\
 	createResources_r10b.cpp	\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
+	unsupportRsvdFields_r12.cpp	\
 	invalidQID_r10b.cpp		\
 	maxQSizeExceed_r10b.cpp		\
 	completionQInvalid_r10b.cpp	\

--- a/GrpAdminCreateIOSQCmd/grpAdminCreateIOSQCmd.cpp
+++ b/GrpAdminCreateIOSQCmd/grpAdminCreateIOSQCmd.cpp
@@ -19,6 +19,7 @@
 #include "createResources_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "invalidQID_r10b.h"
 #include "maxQSizeExceed_r10b.h"
 #include "completionQInvalid_r10b.h"
@@ -43,10 +44,17 @@ GrpAdminCreateIOSQCmd::GrpAdminCreateIOSQCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminCreateIOSQCmd)
         APPEND_TEST_AT_XLEVEL(AcceptQPriority_r10b, GrpAdminCreateIOSQCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminCreateIOSQCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpAdminCreateIOSQCmd)
+        APPEND_TEST_AT_YLEVEL(MaxQSizeExceed_r10b, GrpAdminCreateIOSQCmd)
+        APPEND_TEST_AT_YLEVEL(CompletionQInvalid_r10b, GrpAdminCreateIOSQCmd)
+        APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminCreateIOSQCmd)
+        APPEND_TEST_AT_XLEVEL(AcceptQPriority_r10b, GrpAdminCreateIOSQCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminCreateIOSQCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminCreateIOSQCmd)
         APPEND_TEST_AT_YLEVEL(MaxQSizeExceed_r10b, GrpAdminCreateIOSQCmd)
         APPEND_TEST_AT_YLEVEL(CompletionQInvalid_r10b, GrpAdminCreateIOSQCmd)
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminCreateIOSQCmd)

--- a/GrpAdminCreateIOSQCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminCreateIOSQCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Utils/queues.h"
+#include "../Utils/io.h"
+
+namespace GrpAdminCreateIOSQCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.4");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Find 1st bare namspc, or find 1st meta namspc, or find 1st E2E "
+        "namspc. Unsupported DW's and rsvd fields are treated identical, the "
+        "recipient is not required to check their value. Receipt of reserved "
+        "coded values shall be reported as an error. Issue a CreateIOCQ cmd "
+        "with QID=1, num elements=2, and then issue a corresponding "
+        "CreateIOSQ, same parameters, but set all unsupported/rsvd fields, "
+        "expect success. Set: DW0_b14:10, DW2, DW3, DW4, DW5, DW6, DW7, "
+        "DW11_b15:3, DW12, DW13, DW14, DW15. Issue a write cmd sending 1 block "
+        "and approp supporting meta/E2E if necessary to the selected namspc at "
+        "LBA 0, data pattern of word++, read back, verify pattern.");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+
+    if ((preserve == false) && gCmdLine.rsvdfields)
+        return RUN_TRUE;
+    return RUN_FALSE;    // Optional test skipped or is destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+    uint64_t maxIOQEntries = 2;
+
+    // Lookup objs which were created in a prior test within group
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Setup element sizes for the IOQ's");
+    uint8_t iocqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_CQES) & 0xf);
+    uint8_t iosqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_SQES) & 0xf);
+    gCtrlrConfig->SetIOCQES(iocqes);
+    gCtrlrConfig->SetIOSQES(iosqes);
+
+    LOG_NRM("Create IOCQ");
+    SharedIOCQPtr iocq = Queues::CreateIOCQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, true, 0);
+
+    LOG_NRM("Create IOSQ");
+    SharedIOSQPtr iosq = SharedIOSQPtr(new IOSQ(gDutFd));
+
+    LOG_NRM("Allocate contiguous memory; IOSQ has ID=%d", IOQ_ID);
+    iosq->Init(IOQ_ID, maxIOQEntries, IOQ_ID, 0);
+
+    LOG_NRM("Form a Create IOSQ cmd to perform queue creation");
+    SharedCreateIOSQPtr createIOSQCmd = SharedCreateIOSQPtr(new CreateIOSQ());
+    createIOSQCmd->Init(iosq);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = createIOSQCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    createIOSQCmd->SetDword(work, 0);
+
+    createIOSQCmd->SetDword(0xffffffff, 2);
+    createIOSQCmd->SetDword(0xffffffff, 3);
+    createIOSQCmd->SetDword(0xffffffff, 4);
+    createIOSQCmd->SetDword(0xffffffff, 5);
+    createIOSQCmd->SetDword(0xffffffff, 6);
+    createIOSQCmd->SetDword(0xffffffff, 7);
+
+    // DW11_b15:3
+    work = createIOSQCmd->GetDword(11);
+    work |= 0x0000fff8;
+    createIOSQCmd->SetDword(work, 11);
+
+    createIOSQCmd->SetDword(0xffffffff, 12);
+    createIOSQCmd->SetDword(0xffffffff, 13);
+    createIOSQCmd->SetDword(0xffffffff, 14);
+    createIOSQCmd->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        createIOSQCmd, "", true);
+
+    WriteReadVerify(iosq, iocq);
+
+    Queues::DeleteIOSQToHdw(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+        asq, acq, "", false);
+    Queues::DeleteIOCQToHdw(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iocq,
+        asq, acq, "", false);
+}
+
+
+void
+UnsupportRsvdFields_r12::WriteReadVerify(SharedIOSQPtr iosq,
+    SharedIOCQPtr iocq)
+{
+    Informative::Namspc namspcData = gInformative->Get1stBareMetaE2E();
+    LBAFormat lbaFormat = namspcData.idCmdNamspc->GetLBAFormat();
+    uint64_t lbaDataSize = namspcData.idCmdNamspc->GetLBADataSize();
+
+    SharedWritePtr writeCmd = SharedWritePtr(new Write());
+    SharedMemBufferPtr writeMem = SharedMemBufferPtr(new MemBuffer());
+
+    SharedReadPtr readCmd = SharedReadPtr(new Read());
+    SharedMemBufferPtr readMem = SharedMemBufferPtr(new MemBuffer());
+
+    send_64b_bitmask prpBitmask = (send_64b_bitmask)
+        (MASK_PRP1_PAGE | MASK_PRP2_PAGE | MASK_PRP2_LIST);
+
+    switch (namspcData.type) {
+    case Informative::NS_BARE:
+        writeMem->Init(lbaDataSize);
+        readMem->Init(lbaDataSize);
+        break;
+    case Informative::NS_METAS:
+        writeMem->Init(lbaDataSize);
+        readMem->Init(lbaDataSize);
+        if (gRsrcMngr->SetMetaAllocSize(lbaFormat.MS) == false)
+            throw FrmwkEx(HERE);
+        writeCmd->AllocMetaBuffer();
+        readCmd->AllocMetaBuffer();
+        break;
+    case Informative::NS_METAI:
+        writeMem->Init(lbaDataSize + lbaFormat.MS);
+        readMem->Init(lbaDataSize + lbaFormat.MS);
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+        throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+        break;
+    }
+
+    writeCmd->SetPrpBuffer(prpBitmask, writeMem);
+    writeCmd->SetNSID(namspcData.id);
+    writeCmd->SetNLB(0);
+
+    readCmd->SetPrpBuffer(prpBitmask, readMem);
+    readCmd->SetNSID(namspcData.id);
+    readCmd->SetNLB(0);
+
+    switch (namspcData.type) {
+    case Informative::NS_BARE:
+        writeMem->SetDataPattern(DATAPAT_INC_32BIT);
+        break;
+    case Informative::NS_METAS:
+        writeMem->SetDataPattern(DATAPAT_INC_32BIT);
+        writeCmd->SetMetaDataPattern(DATAPAT_INC_32BIT);
+        break;
+    case Informative::NS_METAI:
+        writeMem->SetDataPattern(DATAPAT_INC_32BIT);
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+        throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+        break;
+    }
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+        iocq, writeCmd, "", true);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+        iocq, readCmd, "", true);
+
+    VerifyDataPat(readCmd, writeCmd);
+}
+
+
+void
+UnsupportRsvdFields_r12::VerifyDataPat(SharedReadPtr readCmd,
+    SharedWritePtr writeCmd)
+{
+    LOG_NRM("Compare read vs written data to verify");
+    SharedMemBufferPtr rdPayload = readCmd->GetRWPrpBuffer();
+    SharedMemBufferPtr wrPayload = writeCmd->GetRWPrpBuffer();
+    if (rdPayload->Compare(wrPayload) == false) {
+        readCmd->Dump(
+            FileSystem::PrepDumpFile(mGrpName, mTestName, "ReadCmd"),
+            "Read command");
+        writeCmd->Dump(
+            FileSystem::PrepDumpFile(mGrpName, mTestName, "WriteCmd"),
+            "Write command");
+        throw FrmwkEx(HERE, "Data miscompare");
+    }
+
+    // If meta data is allocated then compare meta data.
+    if (writeCmd->GetMetaBuffer() != NULL) {
+        const uint8_t *metaRdBuff = readCmd->GetMetaBuffer();
+        const uint8_t *metaWrBuff = writeCmd->GetMetaBuffer();
+        if (memcmp(metaRdBuff, metaWrBuff, writeCmd->GetMetaBufferSize())) {
+            readCmd->Dump(
+                FileSystem::PrepDumpFile(mGrpName, mTestName, "ReadCmdMeta"),
+                "Read command with meta data");
+            writeCmd->Dump(
+                FileSystem::PrepDumpFile(mGrpName, mTestName, "WriteCmdMeta"),
+                "Write command with meta data");
+            throw FrmwkEx(HERE, "Meta data miscompare");
+        }
+    }
+}
+
+
+}   // namespace
+

--- a/GrpAdminCreateIOSQCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminCreateIOSQCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Queues/iocq.h"
+#include "../Queues/iosq.h"
+#include "../Cmds/read.h"
+#include "../Cmds/write.h"
+
+namespace GrpAdminCreateIOSQCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    void WriteReadVerify(SharedIOSQPtr iosq, SharedIOCQPtr iocq);
+    void VerifyDataPat(SharedReadPtr readCmd, SharedWritePtr writeCmd);
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminDeleteIOCQCmd/Makefile
+++ b/GrpAdminDeleteIOCQCmd/Makefile
@@ -21,6 +21,7 @@ SRC =					\
 	createResources_r10b.cpp	\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
+	unsupportRsvdFields_r12.cpp	\
 	invalidQID_r10b.cpp		\
 	deleteAllAtOnce_r10b.cpp	\
 	deleteFullQ_r10b.cpp

--- a/GrpAdminDeleteIOCQCmd/grpAdminDeleteIOCQCmd.cpp
+++ b/GrpAdminDeleteIOCQCmd/grpAdminDeleteIOCQCmd.cpp
@@ -19,6 +19,7 @@
 #include "createResources_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "invalidQID_r10b.h"
 #include "deleteAllAtOnce_r10b.h"
 #include "deleteFullQ_r10b.h"
@@ -41,10 +42,16 @@ GrpAdminDeleteIOCQCmd::GrpAdminDeleteIOCQCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(DeleteAllAtOnce_r10b, GrpAdminDeleteIOCQCmd)
         APPEND_TEST_AT_XLEVEL(DeleteFullQ_r10b, GrpAdminDeleteIOCQCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminDeleteIOCQCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpAdminDeleteIOCQCmd)
+        APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminDeleteIOCQCmd)
+        APPEND_TEST_AT_XLEVEL(DeleteAllAtOnce_r10b, GrpAdminDeleteIOCQCmd)
+        APPEND_TEST_AT_XLEVEL(DeleteFullQ_r10b, GrpAdminDeleteIOCQCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminDeleteIOCQCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminDeleteIOCQCmd)
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminDeleteIOCQCmd)
         APPEND_TEST_AT_XLEVEL(DeleteAllAtOnce_r10b, GrpAdminDeleteIOCQCmd)
         APPEND_TEST_AT_XLEVEL(DeleteFullQ_r10b, GrpAdminDeleteIOCQCmd)

--- a/GrpAdminDeleteIOCQCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminDeleteIOCQCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Cmds/deleteIOCQ.h"
+#include "../Utils/queues.h"
+#include "../Utils/io.h"
+
+namespace GrpAdminDeleteIOCQCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.5");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the "
+        "recipient is not required to check their value. Receipt of reserved "
+        "coded values shall be reported as an error. Issue a CreateIOCQ cmd "
+        "with QID=1, num elements=2. Issue a DeleteIOCQ cmd deleting QID=1, "
+        "expect success. Reissue identical CreateIOCQ, and issue same "
+        "DeleteIOCQ cmd but set all unsupported/rsvd fields, expect success. "
+        "Set: DW0_b14:10, DW2, DW3, DW4, DW5, DW6, DW7, DW8, DW9, DW10_b31:16, "
+        "DW11, DW12, DW13, DW14, DW15");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+    uint64_t maxIOQEntries = 2;
+
+    // Lookup objs which were created in a prior test within group
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Setup element sizes for the IOQ's");
+    uint8_t iocqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_CQES) & 0xf);
+    uint8_t iosqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_SQES) & 0xf);
+    gCtrlrConfig->SetIOCQES(iocqes);
+    gCtrlrConfig->SetIOSQES(iosqes);
+
+    LOG_NRM("Create IOCQ/IOSQ pairs");
+    SharedIOCQPtr iocq = Queues::CreateIOCQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, true, 0);
+
+    LOG_NRM("Delete the IOCQ");
+    SharedDeleteIOCQPtr deleteIOCQCmd = SharedDeleteIOCQPtr(new DeleteIOCQ());
+    deleteIOCQCmd->Init(iocq);
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        deleteIOCQCmd, "", true);
+
+    LOG_NRM("Recreate IOCQ");
+    iocq = Queues::CreateIOCQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, true, 0);
+
+    deleteIOCQCmd->Init(iocq);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = deleteIOCQCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    deleteIOCQCmd->SetDword(work, 0);
+
+    deleteIOCQCmd->SetDword(0xffffffff, 2);
+    deleteIOCQCmd->SetDword(0xffffffff, 3);
+    deleteIOCQCmd->SetDword(0xffffffff, 4);
+    deleteIOCQCmd->SetDword(0xffffffff, 5);
+    deleteIOCQCmd->SetDword(0xffffffff, 6);
+    deleteIOCQCmd->SetDword(0xffffffff, 7);
+    deleteIOCQCmd->SetDword(0xffffffff, 8);
+    deleteIOCQCmd->SetDword(0xffffffff, 9);
+
+    // DW10_b31:16
+    work = deleteIOCQCmd->GetDword(10);
+    work |= 0xffff0000;
+    deleteIOCQCmd->SetDword(work, 10);
+
+    deleteIOCQCmd->SetDword(0xffffffff, 11);
+    deleteIOCQCmd->SetDword(0xffffffff, 12);
+    deleteIOCQCmd->SetDword(0xffffffff, 13);
+    deleteIOCQCmd->SetDword(0xffffffff, 14);
+    deleteIOCQCmd->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        deleteIOCQCmd, "", true);
+}
+
+
+}   // namespace
+

--- a/GrpAdminDeleteIOCQCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminDeleteIOCQCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+
+namespace GrpAdminDeleteIOCQCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminDeleteIOSQCmd/Makefile
+++ b/GrpAdminDeleteIOSQCmd/Makefile
@@ -21,6 +21,7 @@ SRC =					\
 	createResources_r10b.cpp	\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
+	unsupportRsvdFields_r12.cpp	\
 	invalidQID_r10b.cpp
 
 .SUFFIXES: .cpp

--- a/GrpAdminDeleteIOSQCmd/grpAdminDeleteIOSQCmd.cpp
+++ b/GrpAdminDeleteIOSQCmd/grpAdminDeleteIOSQCmd.cpp
@@ -19,6 +19,7 @@
 #include "createResources_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "invalidQID_r10b.h"
 
 namespace GrpAdminDeleteIOSQCmd {
@@ -37,10 +38,14 @@ GrpAdminDeleteIOSQCmd::GrpAdminDeleteIOSQCmd(size_t grpNum) :
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r10b, GrpAdminDeleteIOSQCmd)
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminDeleteIOSQCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminDeleteIOSQCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpAdminDeleteIOSQCmd)
+        APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminDeleteIOSQCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminDeleteIOSQCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminDeleteIOSQCmd)
         APPEND_TEST_AT_XLEVEL(InvalidQID_r10b, GrpAdminDeleteIOSQCmd)
         break;
 

--- a/GrpAdminDeleteIOSQCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminDeleteIOSQCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Cmds/deleteIOSQ.h"
+#include "../Utils/queues.h"
+#include "../Utils/io.h"
+
+namespace GrpAdminDeleteIOSQCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.6");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the recipient "
+        "is not required to check their value. Receipt of reserved coded "
+        "values shall be reported as an error. Issue a CreateIOCQ cmd with "
+        "QID=1, num elements=2. Assoc a CreateIOSQ cmd with QID=1, num "
+        "elements=2. Issue a DeleteIOSQ cmd deleting QID=1, expect success. "
+        "Reissue identical CreateIOSQ, and issue same DeleteIOSQ cmd but set "
+        "all unsupported/rsvd fields, expect success. Set: DW0_b14:10, DW2, "
+        "DW3, DW4, DW5, DW6, DW7, DW8, DW9, DW10_b31:16, DW11, DW12, DW13, "
+        "DW14, DW15");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if ((preserve == false) && gCmdLine.rsvdfields)
+        return RUN_TRUE;
+    return RUN_FALSE;    // Optional test skipped or is destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+    uint64_t maxIOQEntries = 2;
+
+    // Lookup objs which were created in a prior test within group
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Setup element sizes for the IOQ's");
+    uint8_t iocqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_CQES) & 0xf);
+    uint8_t iosqes = (gInformative->GetIdentifyCmdCtrlr()->
+        GetValue(IDCTRLRCAP_SQES) & 0xf);
+    gCtrlrConfig->SetIOCQES(iocqes);
+    gCtrlrConfig->SetIOSQES(iosqes);
+
+    LOG_NRM("Create IOCQ/IOSQ pairs");
+    SharedIOCQPtr iocq = Queues::CreateIOCQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, true, 0);
+    SharedIOSQPtr iosq = Queues::CreateIOSQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, IOQ_ID, 0);
+
+    LOG_NRM("Delete the IOSQ");
+    SharedDeleteIOSQPtr deleteIOSQCmd = SharedDeleteIOSQPtr(new DeleteIOSQ());
+    deleteIOSQCmd->Init(iosq);
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        deleteIOSQCmd, "", true);
+
+    LOG_NRM("Recreate IOSQ");
+    iosq = Queues::CreateIOSQContigToHdw(mGrpName, mTestName,
+        CALC_TIMEOUT_ms(1), asq, acq, IOQ_ID, maxIOQEntries, false,
+        IOCQ_GROUP_ID, IOQ_ID, 0);
+
+    deleteIOSQCmd->Init(iosq);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = deleteIOSQCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    deleteIOSQCmd->SetDword(work, 0);
+
+    deleteIOSQCmd->SetDword(0xffffffff, 2);
+    deleteIOSQCmd->SetDword(0xffffffff, 3);
+    deleteIOSQCmd->SetDword(0xffffffff, 4);
+    deleteIOSQCmd->SetDword(0xffffffff, 5);
+    deleteIOSQCmd->SetDword(0xffffffff, 6);
+    deleteIOSQCmd->SetDword(0xffffffff, 7);
+    deleteIOSQCmd->SetDword(0xffffffff, 8);
+    deleteIOSQCmd->SetDword(0xffffffff, 9);
+
+    // DW10_b31:16
+    work = deleteIOSQCmd->GetDword(10);
+    work |= 0xffff0000;
+    deleteIOSQCmd->SetDword(work, 10);
+
+    deleteIOSQCmd->SetDword(0xffffffff, 11);
+    deleteIOSQCmd->SetDword(0xffffffff, 12);
+    deleteIOSQCmd->SetDword(0xffffffff, 13);
+    deleteIOSQCmd->SetDword(0xffffffff, 14);
+    deleteIOSQCmd->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        deleteIOSQCmd, "", true);
+}
+
+
+}   // namespace
+

--- a/GrpAdminDeleteIOSQCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminDeleteIOSQCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+
+namespace GrpAdminDeleteIOSQCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminGetFeatCmd/Makefile
+++ b/GrpAdminGetFeatCmd/Makefile
@@ -23,7 +23,8 @@ SRC =					\
 	invalidFieldInCmd_r11.cpp	\
 	invalidFieldInCmd_r12.cpp	\
 	unsupportRsvdFields_r10b.cpp \
-	unsupportRsvdFields_r11b.cpp
+	unsupportRsvdFields_r11b.cpp \
+	unsupportRsvdFields_r12.cpp
 
 .SUFFIXES: .cpp
 

--- a/GrpAdminGetFeatCmd/grpAdminGetFeatCmd.cpp
+++ b/GrpAdminGetFeatCmd/grpAdminGetFeatCmd.cpp
@@ -21,6 +21,7 @@
 #include "invalidFieldInCmd_r12.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 
 
 namespace GrpAdminGetFeatCmd {
@@ -47,7 +48,7 @@ GrpAdminGetFeatCmd::GrpAdminGetFeatCmd(size_t grpNum) :
     case SPECREV_12:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminGetFeatCmd)
         APPEND_TEST_AT_YLEVEL(InvalidFieldInCmd_r12, GrpAdminGetFeatCmd)
-        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpAdminGetFeatCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminGetFeatCmd)
         break;
 
     default:

--- a/GrpAdminGetFeatCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminGetFeatCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <boost/utility/binary.hpp>
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Utils/kernelAPI.h"
+#include "../Utils/io.h"
+#include "../Cmds/getFeatures.h"
+
+#define FEATURE_ID      0x01
+
+namespace GrpAdminGetFeatCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.9");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the recipient "
+        "is not required to check their value. Receipt of reserved coded "
+        "values shall be reported as an error. Issue a GetFeature cmd with "
+        "DW10.FID = 0x01, and set bits DW0_b14:10, DW2, DW3, DW4, DW5, "
+        "DW10_31:11, DW12, DW13, DW14, DW15, expect success. Issue same cmd "
+        "setting all rsvd coded values, expect fail. Set: DW10_b10:8, "
+        "DW10_b7:0");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+
+    // Lookup objs which were created in a prior test within group
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Create Get features cmd");
+    SharedGetFeaturesPtr getFeaturesCmd =
+        SharedGetFeaturesPtr(new GetFeatures());
+    getFeaturesCmd->SetFID(FEATURE_ID);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = getFeaturesCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    getFeaturesCmd->SetDword(work, 0);
+
+    getFeaturesCmd->SetDword(0xffffffff, 2);
+    getFeaturesCmd->SetDword(0xffffffff, 3);
+    getFeaturesCmd->SetDword(0xffffffff, 4);
+    getFeaturesCmd->SetDword(0xffffffff, 5);
+    getFeaturesCmd->SetDword(0xffffffff, 6);
+    getFeaturesCmd->SetDword(0xffffffff, 7);
+    getFeaturesCmd->SetDword(0xffffffff, 8);
+    getFeaturesCmd->SetDword(0xffffffff, 9);
+
+    // DW10_b31:11
+    work = getFeaturesCmd->GetDword(10);
+    work |= 0xffffc000;
+    getFeaturesCmd->SetDword(work, 10);
+
+    getFeaturesCmd->SetDword(0xffffffff, 12);
+    getFeaturesCmd->SetDword(0xffffffff, 13);
+    getFeaturesCmd->SetDword(0xffffffff, 14);
+    getFeaturesCmd->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        getFeaturesCmd, "rsvd.set", true);
+
+    uint32_t cdw10 = getFeaturesCmd->GetDword(10) & ~0x3ff;
+    uint64_t oncs = gInformative->GetIdentifyCmdCtrlr()->GetValue(
+            IDCTRLRCAP_ONCS);
+    uint64_t savSelSupp = (oncs & ONCS_SUP_SV_AND_SLCT_FEATS) >> 4;
+
+    if (savSelSupp != 0) {
+        LOG_NRM("Select field supported, test reserved values");
+        for (uint32_t select = BOOST_BINARY(100); select <= BOOST_BINARY(111);
+                ++select) {
+            work = cdw10 | (select << 8);
+            getFeaturesCmd->SetDword(work, 10);
+
+            IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq,
+                    acq, getFeaturesCmd, "rsvd.val.set", true,
+                    CESTAT_INVAL_FIELD);
+        }
+    }
+
+    LOG_NRM("Test reserved FID values");
+    for (uint32_t fid = 0xd; fid <= 0x7f; ++fid) {
+        work = cdw10 | fid;
+        getFeaturesCmd->SetDword(work, 10);
+
+        IO::SendAndReapCmdNot(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+                getFeaturesCmd, "rsvd.val.set", true, CESTAT_SUCCESS);
+    }
+}
+
+}   // namespace

--- a/GrpAdminGetFeatCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminGetFeatCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+
+namespace GrpAdminGetFeatCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);;
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminGetLogPgCmd/Makefile
+++ b/GrpAdminGetLogPgCmd/Makefile
@@ -26,6 +26,7 @@ SRC =					\
 	numDIsAdhered_r10b.cpp		\
 	invalidLogPageNVMSet_r10b.cpp	\
 	invalidLogPageNVMSet_r11b.cpp	\
+	invalidLogPageNVMSet_r12.cpp	\
 	invalidNamspc_r10b.cpp		\
 	invalidNamspc_r11a.cpp		\
 	mandatoryErrInfo_r10b.cpp	\

--- a/GrpAdminGetLogPgCmd/grpAdminGetLogPgCmd.cpp
+++ b/GrpAdminGetLogPgCmd/grpAdminGetLogPgCmd.cpp
@@ -53,12 +53,23 @@ GrpAdminGetLogPgCmd::GrpAdminGetLogPgCmd(size_t grpNum) :
         APPEND_TEST_AT_YLEVEL(MandatorySMART_r10b, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(MandatoryFW_r10b, GrpAdminGetLogPgCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(PRP1_r10b, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(PRP1PRP2_r10b, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(NUMDIsAdhered_r10b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(InvalidLogPageNVMSet_r11b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(InvalidNamspc_r11a, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(MandatoryErrInfo_r10b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(MandatorySMART_r10b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(MandatoryFW_r10b, GrpAdminGetLogPgCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(PRP1_r10b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(PRP1PRP2_r10b, GrpAdminGetLogPgCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(NUMDIsAdhered_r10b, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(InvalidLogPageNVMSet_r11b, GrpAdminGetLogPgCmd)
         APPEND_TEST_AT_YLEVEL(InvalidNamspc_r11a, GrpAdminGetLogPgCmd)

--- a/GrpAdminGetLogPgCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminGetLogPgCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <boost/format.hpp>
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Utils/kernelAPI.h"
+#include "../Utils/io.h"
+#include "../Cmds/getLogPage.h"
+
+#define FIRM_SLOT_INFO_LID      0x03
+#define PRP1_ONLY_NUMD          (514 / 4)
+#define BUFFER_OFFSET           0
+
+namespace GrpAdminGetLogPgCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(string grpName,
+    string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.10");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the "
+        "recipient is not required to check their value. Receipt of reserved "
+        "coded values shall be reported as an error. Issue GetLogPage cmd, "
+        "LID=3, NUMD=(512/4), expect success. Then issue same cmd setting "
+        "all unsupported/rsvd fields, expect success. Set: DW0_b14:10, "
+        "DW2, DW3, DW4, DW5, DW10_b31:28, DW11, DW12, DW13, DW14, DW15. Issue "
+        "same cmd setting all rsvd coded values, expect fail.  Set: DW10_b7:0");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     *  \endverbatim
+     */
+    // Lookup objs which were created in a prior test within group
+    string globalWork;
+    //uint64_t i;
+    
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Create get log page cmd and assoc some buffer memory");
+    SharedGetLogPagePtr getLogPgCmd = SharedGetLogPagePtr(new GetLogPage());
+
+    LOG_NRM("Get log page to request firmware slot information");
+    getLogPgCmd->SetNUMD(PRP1_ONLY_NUMD - 1); // 0-based
+    getLogPgCmd->SetLID(FIRM_SLOT_INFO_LID);
+    getLogPgCmd->SetNSID(0xFFFFFFFF);
+    
+    SharedMemBufferPtr getLogPageMem = SharedMemBufferPtr(new MemBuffer());
+    getLogPageMem->InitOffset1stPage(GetLogPage::FIRMSLOT_DATA_SIZE,
+        BUFFER_OFFSET, true);
+    send_64b_bitmask prpReq =
+        (send_64b_bitmask)(MASK_PRP1_PAGE | MASK_PRP2_PAGE);
+    getLogPgCmd->SetPrpBuffer(prpReq, getLogPageMem);
+
+    LOG_NRM("Issue GetLogPage cmd without setting reserved bits.");
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        getLogPgCmd, "rsvd.notset", true);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = getLogPgCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    getLogPgCmd->SetDword(work, 0);
+
+    getLogPgCmd->SetDword(0xffffffff, 2);
+    getLogPgCmd->SetDword(0xffffffff, 3);
+    getLogPgCmd->SetDword(0xffffffff, 4);
+    getLogPgCmd->SetDword(0xffffffff, 5);
+
+    work = getLogPgCmd->GetDword(10);
+    work |= 0xf0000000;      // Set DW10_b31:28 bits
+    getLogPgCmd->SetDword(work, 10);
+
+    getLogPgCmd->SetDword(0xffffffff, 11);
+    getLogPgCmd->SetDword(0xffffffff, 12);
+    getLogPgCmd->SetDword(0xffffffff, 13);
+    getLogPgCmd->SetDword(0xffffffff, 14);
+    getLogPgCmd->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        getLogPgCmd, "rsvd.set", true);
+
+    LOG_NRM("Set LID field reserved coded values");
+    uint32_t cdw10 = getLogPgCmd->GetDword(10) & ~0xff;
+
+    getLogPgCmd->SetDword(cdw10, 10);
+
+    IO::SendAndReapCmdNot(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+            getLogPgCmd, "rsvd.set", true, CESTAT_SUCCESS);
+
+    for (uint32_t lid = 0x4; lid <= 0x7f; ++lid) {
+        work = cdw10 | lid;
+        getLogPgCmd->SetDword(work, 10);
+
+        IO::SendAndReapCmdNot(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+            getLogPgCmd, "rsvd.val.set", true, CESTAT_SUCCESS);
+    }
+
+    uint8_t css;
+    gCtrlrConfig->GetCSS(css);
+    if (css == 0) { /* NVM Command Set selected */
+        for (uint32_t lid = 0x81; lid <= 0xbf; ++lid) {
+            work = cdw10 | lid;
+            getLogPgCmd->SetDword(work, 10);
+
+            IO::SendAndReapCmdNot(mGrpName, mTestName, CALC_TIMEOUT_ms(1),
+                asq, acq, getLogPgCmd, "rsvd.val.set", true);
+        }
+    }
+
+    else
+    {
+        throw new FrmwkEx(HERE, "Unsupported command set selected for test "
+                "revision: %hhX", css);
+    }
+}
+
+}   // namespace

--- a/GrpAdminGetLogPgCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminGetLogPgCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+
+namespace GrpAdminGetLogPgCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);;
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+};
+
+}   // namespace
+
+#endif

--- a/GrpAdminIdentifyCmd/Makefile
+++ b/GrpAdminIdentifyCmd/Makefile
@@ -23,7 +23,9 @@ SRC =					\
 	prp1PRP2_r10b.cpp		\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
-	invalidNamspc_r10b.cpp
+	unsupportRsvdFields_r12.cpp	\
+	invalidNamspc_r10b.cpp		\
+	endToEnd_r12.cpp
 
 .SUFFIXES: .cpp
 

--- a/GrpAdminIdentifyCmd/grpAdminIdentifyCmd.cpp
+++ b/GrpAdminIdentifyCmd/grpAdminIdentifyCmd.cpp
@@ -20,7 +20,9 @@
 #include "prp1PRP2_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "invalidNamspc_r10b.h"
+#include "endToEnd_r12.h"
 
 
 namespace GrpAdminIdentifyCmd {
@@ -41,6 +43,13 @@ GrpAdminIdentifyCmd::GrpAdminIdentifyCmd(size_t grpNum) :
         APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpAdminIdentifyCmd)
         break;
     case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminIdentifyCmd)
+        APPEND_TEST_AT_YLEVEL(PRP1_r10b, GrpAdminIdentifyCmd)
+        APPEND_TEST_AT_YLEVEL(PRP1PRP2_r10b, GrpAdminIdentifyCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpAdminIdentifyCmd)
+        APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpAdminIdentifyCmd)
+        APPEND_TEST_AT_XLEVEL(EndToEnd_r12, GrpAdminIdentifyCmd)
+        break;
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpAdminIdentifyCmd)
         APPEND_TEST_AT_YLEVEL(PRP1_r10b, GrpAdminIdentifyCmd)

--- a/GrpAdminIdentifyCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminIdentifyCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Utils/kernelAPI.h"
+#include "../Singletons/informative.h"
+#include "../Queues/acq.h"
+#include "../Queues/asq.h"
+#include "../Utils/io.h"
+
+#define PRP_BUFFER_OFFSET       0x0
+
+namespace GrpAdminIdentifyCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 5.11");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the recipient "
+        "is not required to check their value. Receipt of reserved coded "
+        "values shall be reported as an error. Issue Identify cmd requesting "
+        "ctrlr namspc, expect success. Then issue same cmd setting all "
+        "unsupported/rsvd fields, expect success. Set: DW0_b14:10, DW2, DW3, "
+        "DW4, DW5, DW10_b31:2, DW11, DW12, DW13, DW14, DW15. Issue same cmd "
+        "setting all rsvd coded values, expect fail. Set: DW10_b1:0");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+
+    LOG_NRM("Lookup objs which were created in a prior test within group");
+    SharedASQPtr asq = CAST_TO_ASQ(gRsrcMngr->GetObj(ASQ_GROUP_ID))
+    SharedACQPtr acq = CAST_TO_ACQ(gRsrcMngr->GetObj(ACQ_GROUP_ID))
+
+    LOG_NRM("Determine if DUT has atleast one namespace support");
+    ConstSharedIdentifyPtr idCmdCtrlr = gInformative->GetIdentifyCmdCtrlr();
+    if ((idCmdCtrlr->GetValue(IDCTRLRCAP_NN)) == 0)
+        throw FrmwkEx(HERE, "Required to support >= 1 namespace");
+
+    LOG_NRM("Form identify namespace cmd and associate some buffer");
+    SharedIdentifyPtr idCmdNamSpc = SharedIdentifyPtr(new Identify());
+    idCmdNamSpc->SetCNS(CNS_Namespace);
+    idCmdNamSpc->SetNSID(1);
+
+    SharedMemBufferPtr idMemNamSpc = SharedMemBufferPtr(new MemBuffer());
+    idMemNamSpc->InitOffset1stPage(Identify::IDEAL_DATA_SIZE,
+        PRP_BUFFER_OFFSET, true);
+
+    LOG_NRM("Allow PRP1 and PRP2");
+    send_64b_bitmask idPrpNamSpc =
+        (send_64b_bitmask)(MASK_PRP1_PAGE | MASK_PRP2_PAGE);
+    idCmdNamSpc->SetPrpBuffer(idPrpNamSpc, idMemNamSpc);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        idCmdNamSpc, "rsvdnone.set", true);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = idCmdNamSpc->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    idCmdNamSpc->SetDword(work, 0);
+
+    idCmdNamSpc->SetDword(0xffffffff, 2);
+    idCmdNamSpc->SetDword(0xffffffff, 3);
+    idCmdNamSpc->SetDword(0xffffffff, 4);
+    idCmdNamSpc->SetDword(0xffffffff, 5);
+
+    work = idCmdNamSpc->GetDword(10);
+    work |= 0xfffffffc;      // Set DW10_b31:2 bits
+    idCmdNamSpc->SetDword(work, 10);
+
+    idCmdNamSpc->SetDword(0xffffffff, 11);
+    idCmdNamSpc->SetDword(0xffffffff, 12);
+    idCmdNamSpc->SetDword(0xffffffff, 13);
+    idCmdNamSpc->SetDword(0xffffffff, 14);
+    idCmdNamSpc->SetDword(0xffffffff, 15);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        idCmdNamSpc, "rsvdall.set", true);
+
+    LOG_NRM("Set CNS field reserved coded value");
+    uint32_t cdw10 = idCmdNamSpc->GetDword(10);
+    work = cdw10 | 0x3;
+    idCmdNamSpc->SetDword(work, 10);
+
+    IO::SendAndReapCmdNot(mGrpName, mTestName, CALC_TIMEOUT_ms(1), asq, acq,
+        idCmdNamSpc, "rsvdall.val.set", true, CESTAT_SUCCESS);
+}
+
+}   // namespace

--- a/GrpAdminIdentifyCmd/unsupportRsvdFields_r12.h
+++ b/GrpAdminIdentifyCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+
+namespace GrpAdminIdentifyCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);;
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+};
+
+}   // namespace
+
+#endif

--- a/GrpNVMDatasetMgmtCmd/Makefile
+++ b/GrpNVMDatasetMgmtCmd/Makefile
@@ -22,6 +22,7 @@ SRC =					\
 	invalidNamspc_r10b.cpp		\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
+	unsupportRsvdFields_r12.cpp	\
 	prp1PRP2NR_r10b.cpp		\
 	attributes_r10b.cpp		\
 	verifyNUSE_r10b.cpp

--- a/GrpNVMDatasetMgmtCmd/grpNVMDatasetMgmtCmd.cpp
+++ b/GrpNVMDatasetMgmtCmd/grpNVMDatasetMgmtCmd.cpp
@@ -20,6 +20,7 @@
 #include "invalidNamspc_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "prp1PRP2NR_r10b.h"
 #include "attributes_r10b.h"
 #include "verifyNUSE_r10b.h"
@@ -42,11 +43,18 @@ GrpNVMDatasetMgmtCmd::GrpNVMDatasetMgmtCmd(size_t grpNum) :
         APPEND_TEST_AT_YLEVEL(Attributes_r10b, GrpNVMDatasetMgmtCmd)
         APPEND_TEST_AT_YLEVEL(VerifyNUSE_r10b, GrpNVMDatasetMgmtCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpNVMDatasetMgmtCmd)
         APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpNVMDatasetMgmtCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpNVMDatasetMgmtCmd)
+        APPEND_TEST_AT_YLEVEL(PRP1PRP2NR_r10b, GrpNVMDatasetMgmtCmd)
+        APPEND_TEST_AT_YLEVEL(Attributes_r10b, GrpNVMDatasetMgmtCmd)
+        APPEND_TEST_AT_YLEVEL(VerifyNUSE_r10b, GrpNVMDatasetMgmtCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpNVMDatasetMgmtCmd)
+        APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpNVMDatasetMgmtCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpNVMDatasetMgmtCmd)
         APPEND_TEST_AT_YLEVEL(PRP1PRP2NR_r10b, GrpNVMDatasetMgmtCmd)
         APPEND_TEST_AT_YLEVEL(Attributes_r10b, GrpNVMDatasetMgmtCmd)
         APPEND_TEST_AT_YLEVEL(VerifyNUSE_r10b, GrpNVMDatasetMgmtCmd)

--- a/GrpNVMDatasetMgmtCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpNVMDatasetMgmtCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Queues/iocq.h"
+#include "../Queues/iosq.h"
+#include "../Utils/io.h"
+#include "../Cmds/datasetMgmt.h"
+
+namespace GrpNVMDatasetMgmtCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 6.7");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the recipient "
+        "is not required to check their value. Receipt of reserved coded "
+        "values shall be reported as an error. Determine Identify.NN and issue "
+        "flush cmd to all namspc, expect success. Then issue same cmd setting "
+        "all unsupported/rsvd fields, expect success. Set: DW0_b14:10, DW2, "
+        "DW3, DW4, DW5, DW8, DW9, DW10_b31:8, DW11_b31:3, DW12, DW13, DW14, "
+        "DW15.");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+
+    ConstSharedIdentifyPtr idCtrlrCap = gInformative->GetIdentifyCmdCtrlr();
+    uint64_t oncs = idCtrlrCap->GetValue(IDCTRLRCAP_ONCS);
+    if ((oncs & ONCS_SUP_DSM_CMD) == 0) {
+        LOG_NRM("Reporting not supoorted (oncs)%ld", oncs);
+        return RUN_FALSE;
+    }
+
+    LOG_NRM("Reporting runnable (oncs)%ld", oncs);
+
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+
+    // Lookup objs which were created in a prior test within group
+    SharedIOSQPtr iosq = CAST_TO_IOSQ(gRsrcMngr->GetObj(IOSQ_GROUP_ID));
+    SharedIOCQPtr iocq = CAST_TO_IOCQ(gRsrcMngr->GetObj(IOCQ_GROUP_ID));
+
+    SharedDatasetMgmtPtr datasetMgmtCmd =
+        SharedDatasetMgmtPtr(new DatasetMgmt());
+
+    uint16_t timeout;
+    if (gCmdLine.setAD)
+        timeout = 1000;
+    else
+        timeout = 1;
+
+    ConstSharedIdentifyPtr idCtrlr = gInformative->GetIdentifyCmdCtrlr();
+    for (uint64_t i = 1; i <= idCtrlr->GetValue(IDCTRLRCAP_NN); i++) {
+        LOG_NRM("Processing namspc %ld", i);
+        datasetMgmtCmd->SetNSID(i);
+
+        LOG_NRM("Create memory to contain 1 dataset range def");
+        SharedMemBufferPtr rangeMem = SharedMemBufferPtr(new MemBuffer());
+        rangeMem->Init(sizeof(RangeDef), true);
+        send_64b_bitmask prpReq =
+            (send_64b_bitmask)(MASK_PRP1_PAGE | MASK_PRP2_PAGE);
+        datasetMgmtCmd->SetPrpBuffer(prpReq, rangeMem);
+
+        LOG_NRM("Setup generic range def guidelines");
+        RangeDef *rangeDef = (RangeDef *)rangeMem->GetBuffer();
+        rangeDef->length = 1;
+
+        if (gCmdLine.setAD)
+            datasetMgmtCmd->SetAD(true);
+
+        IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(timeout), iosq,
+            iocq, datasetMgmtCmd, "none.set", true);
+
+        LOG_NRM("Set all cmd's rsvd bits");
+        uint32_t work = datasetMgmtCmd->GetDword(0);
+        work |= 0x00003c00;      // Set DW0_b13:10 bits
+        datasetMgmtCmd->SetDword(work, 0);
+
+        datasetMgmtCmd->SetDword(0xffffffff, 2);
+        datasetMgmtCmd->SetDword(0xffffffff, 3);
+        datasetMgmtCmd->SetDword(0xffffffff, 4);
+        datasetMgmtCmd->SetDword(0xffffffff, 5);
+        datasetMgmtCmd->SetDword(0xffffffff, 8);
+        datasetMgmtCmd->SetDword(0xffffffff, 9);
+
+        work = datasetMgmtCmd->GetDword(10);
+        work |= 0xffffff00;     // Set DW10_b31:8 bits
+        datasetMgmtCmd->SetDword(work, 10);
+
+        work = datasetMgmtCmd->GetDword(11);
+        work |= 0xfffffff8;     // Set DW11_b31:3 bits
+        if (gCmdLine.setAD)
+            work |= 0x4; // Set Bit2 AD=1 (Deallocate)
+        datasetMgmtCmd->SetDword(work, 11);
+
+        datasetMgmtCmd->SetDword(0xffffffff, 12);
+        datasetMgmtCmd->SetDword(0xffffffff, 13);
+        datasetMgmtCmd->SetDword(0xffffffff, 14);
+        datasetMgmtCmd->SetDword(0xffffffff, 15);
+
+        IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(timeout), iosq,
+            iocq, datasetMgmtCmd, "all.set", true);
+    }
+}
+
+
+}   // namespace
+

--- a/GrpNVMDatasetMgmtCmd/unsupportRsvdFields_r12.h
+++ b/GrpNVMDatasetMgmtCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Cmds/read.h"
+
+namespace GrpNVMDatasetMgmtCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    SharedReadPtr CreateCmd();
+};
+
+}   // namespace
+
+#endif

--- a/GrpNVMFlushCmd/Makefile
+++ b/GrpNVMFlushCmd/Makefile
@@ -22,6 +22,7 @@ SRC =					\
 	invalidNamspc_r10b.cpp		\
 	unsupportRsvdFields_r10b.cpp	\
 	unsupportRsvdFields_r11b.cpp	\
+	unsupportRsvdFields_r12.cpp		\
 	functionalityBare_r10b.cpp	\
 	functionalityMeta_r10b.cpp
 

--- a/GrpNVMFlushCmd/grpNVMFlushCmd.cpp
+++ b/GrpNVMFlushCmd/grpNVMFlushCmd.cpp
@@ -20,6 +20,7 @@
 #include "invalidNamspc_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "functionalityBare_r10b.h"
 #include "functionalityMeta_r10b.h"
 
@@ -40,11 +41,17 @@ GrpNVMFlushCmd::GrpNVMFlushCmd(size_t grpNum) :
         APPEND_TEST_AT_YLEVEL(FunctionalityBare_r10b, GrpNVMFlushCmd)
         APPEND_TEST_AT_XLEVEL(FunctionalityMeta_r10b, GrpNVMFlushCmd)
         break;
-    case SPECREV_12:
     case SPECREV_11:
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpNVMFlushCmd)
         APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpNVMFlushCmd)
         APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpNVMFlushCmd)
+        APPEND_TEST_AT_YLEVEL(FunctionalityBare_r10b, GrpNVMFlushCmd)
+        APPEND_TEST_AT_XLEVEL(FunctionalityMeta_r10b, GrpNVMFlushCmd)
+        break;
+    case SPECREV_12:
+        APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpNVMFlushCmd)
+        APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpNVMFlushCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpNVMFlushCmd)
         APPEND_TEST_AT_YLEVEL(FunctionalityBare_r10b, GrpNVMFlushCmd)
         APPEND_TEST_AT_XLEVEL(FunctionalityMeta_r10b, GrpNVMFlushCmd)
         break;

--- a/GrpNVMFlushCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpNVMFlushCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Queues/iocq.h"
+#include "../Queues/iosq.h"
+#include "../Utils/io.h"
+#include "../Cmds/flush.h"
+
+namespace GrpNVMFlushCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 6.8");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Unsupported DW's and rsvd fields are treated identical, the recipient "
+        "is not required to check their value. Receipt of reserved coded "
+        "values shall be reported as an error. Determine Identify.NN and issue "
+        "flush cmd to all namspc, expect success. Then issue same cmd setting "
+        "all unsupported/rsvd fields, expect success. Set: DW0_b15:10, DW2, "
+        "DW3, DW4, DW5, DW6, DW7, DW8, DW9, DW10, DW11, DW12, DW13, DW14, "
+        "DW15.");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+
+    // Lookup objs which were created in a prior test within group
+    SharedIOSQPtr iosq = CAST_TO_IOSQ(gRsrcMngr->GetObj(IOSQ_GROUP_ID));
+    SharedIOCQPtr iocq = CAST_TO_IOCQ(gRsrcMngr->GetObj(IOCQ_GROUP_ID));
+
+    SharedFlushPtr flushCmd = SharedFlushPtr(new Flush());
+    ConstSharedIdentifyPtr idCtrlr = gInformative->GetIdentifyCmdCtrlr();
+    for (uint64_t i = 1; i <= idCtrlr->GetValue(IDCTRLRCAP_NN); i++) {
+        LOG_NRM("Processing namspc %ld", i);
+        flushCmd->SetNSID(i);
+
+        IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq,
+            flushCmd, "none.set", true);
+
+        LOG_NRM("Set all cmd's rsvd bits");
+        uint32_t work = flushCmd->GetDword(0);
+        work |= 0x00003c00;      // Set DW0_b13:10 bits
+        flushCmd->SetDword(work, 0);
+
+        flushCmd->SetDword(0xffffffff, 2);
+        flushCmd->SetDword(0xffffffff, 3);
+        flushCmd->SetDword(0xffffffff, 4);
+        flushCmd->SetDword(0xffffffff, 5);
+        flushCmd->SetDword(0xffffffff, 6);
+        flushCmd->SetDword(0xffffffff, 7);
+        flushCmd->SetDword(0xffffffff, 8);
+        flushCmd->SetDword(0xffffffff, 9);
+        flushCmd->SetDword(0xffffffff, 10);
+        flushCmd->SetDword(0xffffffff, 11);
+        flushCmd->SetDword(0xffffffff, 12);
+        flushCmd->SetDword(0xffffffff, 13);
+        flushCmd->SetDword(0xffffffff, 14);
+        flushCmd->SetDword(0xffffffff, 15);
+
+        IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq,
+            flushCmd, "all.set", true);
+    }
+}
+
+
+}   // namespace
+

--- a/GrpNVMFlushCmd/unsupportRsvdFields_r12.h
+++ b/GrpNVMFlushCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Cmds/read.h"
+
+namespace GrpNVMFlushCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    SharedReadPtr CreateCmd();
+};
+
+}   // namespace
+
+#endif

--- a/GrpNVMReadCmd/Makefile
+++ b/GrpNVMReadCmd/Makefile
@@ -24,6 +24,7 @@ SRC =						\
 	invalidNamspc_r10b.cpp			\
 	unsupportRsvdFields_r10b.cpp		\
 	unsupportRsvdFields_r11b.cpp		\
+	unsupportRsvdFields_r12.cpp		\
 	ignoreMetaPtrBare_r10b.cpp		\
 	ignoreMetaPtrBare_r12.cpp		\
 	protInfoIgnoreBare_r10b.cpp		\

--- a/GrpNVMReadCmd/grpNVMReadCmd.cpp
+++ b/GrpNVMReadCmd/grpNVMReadCmd.cpp
@@ -21,6 +21,7 @@
 #include "invalidNamspc_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "ignoreMetaPtrBare_r10b.h"
 #include "ignoreMetaPtrBare_r12.h"
 #include "protInfoIgnoreBare_r10b.h"
@@ -74,7 +75,7 @@ GrpNVMReadCmd::GrpNVMReadCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(LBAOutOfRangeBare_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpNVMReadCmd)
-        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpNVMReadCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(ProtInfoIgnoreBare_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(IgnoreMetaPtrBare_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(FUA_r10b, GrpNVMReadCmd)

--- a/GrpNVMReadCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpNVMReadCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <boost/utility/binary.hpp>
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Queues/iocq.h"
+#include "../Queues/iosq.h"
+#include "../Utils/io.h"
+
+namespace GrpNVMReadCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 6.9");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Search for 1 of the following namspcs to run test. Find 1st bare "
+        "namspc, or find 1st meta namspc, or find 1st E2E namspc. Unsupported "
+        "DW's and rsvd fields are treated identical, the recipient is not "
+        "required to check their value. Receipt of reserved coded values shall "
+        "be reported as an error. Issue a read cmd requesting 1 block and "
+        "approp supporting meta/E2E if necessary from the selected namspc at "
+        "LBA 0, expect success. Issue same cmd setting all unsupported/rsvd "
+        "fields, expect success. Set: DW0_b14:10, DW2, DW3, DW12_b25:16, "
+        "DW13_b31:8. Issue same cmd setting all rsvd coded values, expect "
+        "fail. Set: DW13_b3:0");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (gCmdLine.rsvdfields == false)
+        return RUN_FALSE;   // Optional rsvd fields test skipped.
+
+    preserve = preserve;    // Suppress compiler error/warning
+    return RUN_TRUE;        // This test is never destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+
+    // Lookup objs which were created in a prior test within group
+    SharedIOSQPtr iosq = CAST_TO_IOSQ(gRsrcMngr->GetObj(IOSQ_GROUP_ID));
+    SharedIOCQPtr iocq = CAST_TO_IOCQ(gRsrcMngr->GetObj(IOCQ_GROUP_ID));
+
+    SharedReadPtr readCmd = CreateCmd();
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq,
+        readCmd, "none.set", true);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = readCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    readCmd->SetDword(work, 0);
+
+    readCmd->SetDword(0xffffffff, 2);
+    readCmd->SetDword(0xffffffff, 3);
+
+    work = readCmd->GetDword(12);
+    work |= 0x03ff0000;      // Set DW12_b25:16 bits
+    readCmd->SetDword(work, 12);
+
+    work = readCmd->GetDword(13);
+    work |= 0xffffff00;     // Set DW13_b31:8 bits
+    readCmd->SetDword(work, 13);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq,
+        readCmd, "all.set", true);
+
+    LOG_NRM("Set DSM field reserved coded values");
+    uint32_t cdw13 = readCmd->GetDword(13) & ~0xf;
+    for (int accFreq = BOOST_BINARY(111); accFreq <= BOOST_BINARY(1111);
+        ++accFreq) {
+        work = cdw13 | accFreq;
+        readCmd->SetDword(work, 13);
+
+        /* Controller may ignore context attributes */
+        IO::SendAndReapCmdIgnore(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+            iocq, readCmd, "all.set", true);
+    }
+}
+
+
+SharedReadPtr
+UnsupportRsvdFields_r12::CreateCmd()
+{
+    Informative::Namspc namspcData = gInformative->Get1stBareMetaE2E();
+    LBAFormat lbaFormat = namspcData.idCmdNamspc->GetLBAFormat();
+    LOG_NRM("Processing read cmd using namspc id %d", namspcData.id);
+
+    ConstSharedIdentifyPtr namSpcPtr = namspcData.idCmdNamspc;
+    uint64_t lbaDataSize = namSpcPtr->GetLBADataSize();;
+    SharedMemBufferPtr dataPat = SharedMemBufferPtr(new MemBuffer());
+
+    SharedReadPtr readCmd = SharedReadPtr(new Read());
+    send_64b_bitmask prpBitmask = (send_64b_bitmask)(MASK_PRP1_PAGE
+        | MASK_PRP2_PAGE | MASK_PRP2_LIST);
+
+    switch (namspcData.type) {
+    case Informative::NS_BARE:
+        dataPat->Init(lbaDataSize);
+        break;
+    case Informative::NS_METAS:
+        dataPat->Init(lbaDataSize);
+        if (gRsrcMngr->SetMetaAllocSize(lbaFormat.MS) == false)
+            throw FrmwkEx(HERE);
+        readCmd->AllocMetaBuffer();
+        break;
+    case Informative::NS_METAI:
+        dataPat->Init(lbaDataSize + lbaFormat.MS);
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+        throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+        break;
+    }
+
+    readCmd->SetPrpBuffer(prpBitmask, dataPat);
+    readCmd->SetNSID(namspcData.id);
+    readCmd->SetNLB(0);
+    return readCmd;
+}
+
+
+}   // namespace
+

--- a/GrpNVMReadCmd/unsupportRsvdFields_r12.h
+++ b/GrpNVMReadCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Cmds/read.h"
+
+namespace GrpNVMReadCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    SharedReadPtr CreateCmd();
+};
+
+}   // namespace
+
+#endif

--- a/GrpNVMWriteCmd/Makefile
+++ b/GrpNVMWriteCmd/Makefile
@@ -24,6 +24,7 @@ SRC =						\
 	invalidNamspc_r10b.cpp			\
 	unsupportRsvdFields_r10b.cpp		\
 	unsupportRsvdFields_r11b.cpp		\
+	unsupportRsvdFields_r12.cpp		\
 	ignoreMetaPtrBare_r10b.cpp		\
 	ignoreMetaPtrBare_r12.cpp		\
 	protInfoIgnoreBare_r10b.cpp		\

--- a/GrpNVMWriteCmd/grpNVMWriteCmd.cpp
+++ b/GrpNVMWriteCmd/grpNVMWriteCmd.cpp
@@ -21,6 +21,7 @@
 #include "invalidNamspc_r10b.h"
 #include "unsupportRsvdFields_r10b.h"
 #include "unsupportRsvdFields_r11b.h"
+#include "unsupportRsvdFields_r12.h"
 #include "ignoreMetaPtrBare_r10b.h"
 #include "ignoreMetaPtrBare_r12.h"
 #include "protInfoIgnoreBare_r10b.h"
@@ -74,7 +75,7 @@ GrpNVMWriteCmd::GrpNVMWriteCmd(size_t grpNum) :
         APPEND_TEST_AT_XLEVEL(CreateResources_r10b, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(LBAOutOfRangeBare_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(InvalidNamspc_r10b, GrpNVMReadCmd)
-        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r11b, GrpNVMReadCmd)
+        APPEND_TEST_AT_YLEVEL(UnsupportRsvdFields_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(ProtInfoIgnoreBare_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(IgnoreMetaPtrBare_r12, GrpNVMReadCmd)
         APPEND_TEST_AT_YLEVEL(FUA_r10b, GrpNVMReadCmd)

--- a/GrpNVMWriteCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpNVMWriteCmd/unsupportRsvdFields_r12.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <boost/utility/binary.hpp>
+
+#include "unsupportRsvdFields_r12.h"
+#include "globals.h"
+#include "grpDefs.h"
+#include "../Queues/iocq.h"
+#include "../Queues/iosq.h"
+#include "../Utils/io.h"
+
+namespace GrpNVMWriteCmd {
+
+
+UnsupportRsvdFields_r12::UnsupportRsvdFields_r12(
+    string grpName, string testName) :
+    Test(grpName, testName, SPECREV_12)
+{
+    // 63 chars allowed:     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mTestDesc.SetCompliance("revision 1.2, section 6.14");
+    mTestDesc.SetShort(     "Set unsupported/rsvd fields in write cmd");
+    // No string size limit for the long description
+    mTestDesc.SetLong(
+        "Search for 1 of the following namspcs to run test. Find 1st bare "
+        "namspc, or find 1st meta namspc, or find 1st E2E namspc. Unsupported "
+        "DW's and rsvd fields are treated identical, the recipient is not "
+        "required to check their value. Receipt of reserved coded values shall "
+        "be reported as an error. Issue a write cmd sending 1 block and approp "
+        "supporting meta/E2E if necessary to the selected namspc at LBA 0, "
+        "expect success. Issue same cmd setting all unsupported/rsvd fields, "
+        "expect success. Set: DW0_b14:10, DW2, DW3, DW12_b25:16, DW13_b31:8.  "
+        "Issue same cmd setting all rsvd coded values, expect fail. "
+        "Set: DW13_b3:0");
+}
+
+
+UnsupportRsvdFields_r12::~UnsupportRsvdFields_r12()
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Allocations taken from the heap and not under the control of the
+    // RsrcMngr need to be freed/deleted here.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12::
+UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other) : Test(other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+
+UnsupportRsvdFields_r12 &
+UnsupportRsvdFields_r12::operator=(const UnsupportRsvdFields_r12 &other)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All pointers in this object must be NULL, never allow shallow or deep
+    // copies, see Test::Clone() header comment.
+    ///////////////////////////////////////////////////////////////////////////
+    Test::operator=(other);
+    return *this;
+}
+
+
+Test::RunType
+UnsupportRsvdFields_r12::RunnableCoreTest(bool preserve)
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // All code contained herein must never permanently modify the state or
+    // configuration of the DUT. Permanence is defined as state or configuration
+    // changes that will not be restored after a cold hard reset.
+    ///////////////////////////////////////////////////////////////////////////
+
+    if ((preserve == false) && gCmdLine.rsvdfields)
+        return RUN_TRUE;
+    return RUN_FALSE;    // Optional test skipped or is destructive
+}
+
+
+void
+UnsupportRsvdFields_r12::RunCoreTest()
+{
+    /** \verbatim
+     * Assumptions:
+     * 1) Test CreateResources_r10b has run prior.
+     * \endverbatim
+     */
+
+    // Lookup objs which were created in a prior test within group
+    SharedIOSQPtr iosq = CAST_TO_IOSQ(gRsrcMngr->GetObj(IOSQ_GROUP_ID));
+    SharedIOCQPtr iocq = CAST_TO_IOCQ(gRsrcMngr->GetObj(IOCQ_GROUP_ID));
+
+    SharedWritePtr writeCmd = CreateCmd();
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq,
+        writeCmd, "none.set", true);
+
+    LOG_NRM("Set all cmd's rsvd bits");
+    uint32_t work = writeCmd->GetDword(0);
+    work |= 0x00003c00;      // Set DW0_b13:10 bits
+    writeCmd->SetDword(work, 0);
+
+    writeCmd->SetDword(0xffffffff, 2);
+    writeCmd->SetDword(0xffffffff, 3);
+
+    work = writeCmd->GetDword(12);
+    work |= 0x03ff0000;      // Set DW12_b25:16 bits
+    writeCmd->SetDword(work, 12);
+
+    work = writeCmd->GetDword(13);
+    work |= 0xffffff00;     // Set DW13_b31:8 bits
+    writeCmd->SetDword(work, 13);
+
+    IO::SendAndReapCmd(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq, iocq,
+        writeCmd, "all.set", true);
+
+    LOG_NRM("Set DSM field reserved coded values");
+    uint32_t cdw13 = writeCmd->GetDword(13) & ~0xf;
+    for (uint32_t accFreq = BOOST_BINARY(111); accFreq <= BOOST_BINARY(1111);
+            ++accFreq) {
+        work = cdw13 | accFreq;
+        writeCmd->SetDword(work, 13);
+
+        /* Controller may ignore context attributes */
+        IO::SendAndReapCmdIgnore(mGrpName, mTestName, CALC_TIMEOUT_ms(1), iosq,
+            iocq, writeCmd, "rsvd.val.set", true);
+    }
+}
+
+
+SharedWritePtr
+UnsupportRsvdFields_r12::CreateCmd()
+{
+    Informative::Namspc namspcData = gInformative->Get1stBareMetaE2E();
+    LBAFormat lbaFormat = namspcData.idCmdNamspc->GetLBAFormat();
+    LOG_NRM("Processing read cmd using namspc id %d", namspcData.id);
+
+    ConstSharedIdentifyPtr namSpcPtr = namspcData.idCmdNamspc;
+    uint64_t lbaDataSize = namSpcPtr->GetLBADataSize();;
+    SharedMemBufferPtr dataPat = SharedMemBufferPtr(new MemBuffer());
+
+    SharedWritePtr writeCmd = SharedWritePtr(new Write());
+    send_64b_bitmask prpBitmask = (send_64b_bitmask)(MASK_PRP1_PAGE
+        | MASK_PRP2_PAGE | MASK_PRP2_LIST);
+
+    switch (namspcData.type) {
+    case Informative::NS_BARE:
+        dataPat->Init(lbaDataSize);
+        break;
+    case Informative::NS_METAS:
+        dataPat->Init(lbaDataSize);
+        if (gRsrcMngr->SetMetaAllocSize(lbaFormat.MS) == false)
+            throw FrmwkEx(HERE);
+        writeCmd->AllocMetaBuffer();
+        break;
+    case Informative::NS_METAI:
+        dataPat->Init(lbaDataSize + lbaFormat.MS);
+        break;
+    case Informative::NS_E2ES:
+    case Informative::NS_E2EI:
+        throw FrmwkEx(HERE, "Deferring work to handle this case in future");
+        break;
+    }
+
+    writeCmd->SetPrpBuffer(prpBitmask, dataPat);
+    writeCmd->SetNSID(namspcData.id);
+    writeCmd->SetNLB(0);
+    return writeCmd;
+}
+
+
+}   // namespace
+

--- a/GrpNVMWriteCmd/unsupportRsvdFields_r12.h
+++ b/GrpNVMWriteCmd/unsupportRsvdFields_r12.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011, Intel Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _UNSUPPORTRSVDFIELDS_r12_H_
+#define _UNSUPPORTRSVDFIELDS_r12_H_
+
+#include "test.h"
+#include "../Cmds/write.h"
+
+namespace GrpNVMWriteCmd {
+
+
+/** \verbatim
+ * -----------------------------------------------------------------------------
+ * ----------------Mandatory rules for children to follow-----------------------
+ * -----------------------------------------------------------------------------
+ * 1) See notes in the header file of the Test base class
+ * \endverbatim
+ */
+class UnsupportRsvdFields_r12 : public Test
+{
+public:
+    UnsupportRsvdFields_r12(string grpName, string testName);
+    virtual ~UnsupportRsvdFields_r12();
+
+    /**
+     * IMPORTANT: Read Test::Clone() header comment.
+     */
+    virtual UnsupportRsvdFields_r12 *Clone() const
+        { return new UnsupportRsvdFields_r12(*this); }
+    UnsupportRsvdFields_r12 &operator=(const UnsupportRsvdFields_r12 &other);
+    UnsupportRsvdFields_r12(const UnsupportRsvdFields_r12 &other);
+
+
+protected:
+    virtual void RunCoreTest();
+    virtual RunType RunnableCoreTest(bool preserve);
+
+
+private:
+    ///////////////////////////////////////////////////////////////////////////
+    // Adding a member variable? Then edit the copy constructor and operator=().
+    ///////////////////////////////////////////////////////////////////////////
+    SharedWritePtr CreateCmd();
+};
+
+}   // namespace
+
+#endif


### PR DESCRIPTION
Created 12 new files to handle a change from spec revision 1.1 to 1.2. The PSDT register now contains two bits of space, one of which was previously reserved (bit 14). The original test would overwrite this bit. The new tests no longer overwrite bit 14 in DW0 which prevents the overwrite of the PSDT value. 

See page 51 of NVMe 1.2 for the new structure.