### PR TITLE
FID_NUM_QUEUES neesds to use the FID array

### DIFF
--- a/Singletons/informative.cpp
+++ b/Singletons/informative.cpp
@@ -484,7 +484,7 @@ Informative::SendGetFeaturesNumOfQueues(SharedASQPtr asq, SharedACQPtr acq,
     LOG_NRM("Create get features");
     SharedGetFeaturesPtr gfNumQ = SharedGetFeaturesPtr(new GetFeatures());
     LOG_NRM("Force get features to request number of queues");
-    gfNumQ->SetFID(FID_NUM_QUEUES);
+    gfNumQ->SetFID(FID[FID_NUM_QUEUES]);
     gfNumQ->Dump(
         FileSystem::PrepDumpFile(GRP_NAME, TEST_NAME, "GetFeat", "NumOfQueue"),
         "The get features number of queues cmd");


### PR DESCRIPTION
Since commit a2e7584888012d11387d34e10105025c21287837, FID values need to
use the FID array, but this one was not.