### PR TITLE
fixes: Use default IOCQES/IOSQES upon device enable

### DIFF
--- a/Exception/frmwkEx.cpp
+++ b/Exception/frmwkEx.cpp
@@ -122,6 +122,8 @@ FrmwkEx::PreliminaryProcessing()
     asq->Init(2);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE, "Exception handler()");
 

--- a/GrpAdminAsyncCmd/abortByReset_r10b.cpp
+++ b/GrpAdminAsyncCmd/abortByReset_r10b.cpp
@@ -120,6 +120,8 @@ AbortByReset_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 
@@ -142,6 +144,8 @@ AbortByReset_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 
@@ -164,6 +168,8 @@ AbortByReset_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminAsyncCmd/unsupportRsvdFields_r10b.cpp
+++ b/GrpAdminAsyncCmd/unsupportRsvdFields_r10b.cpp
@@ -125,6 +125,8 @@ UnsupportRsvdFields_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminAsyncCmd/unsupportRsvdFields_r11b.cpp
+++ b/GrpAdminAsyncCmd/unsupportRsvdFields_r11b.cpp
@@ -124,6 +124,8 @@ UnsupportRsvdFields_r11b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminAsyncCmd/unsupportRsvdFields_r12.cpp
+++ b/GrpAdminAsyncCmd/unsupportRsvdFields_r12.cpp
@@ -124,6 +124,8 @@ UnsupportRsvdFields_r12::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminAsyncCmd/verifyEventQueueing_r10b.cpp
+++ b/GrpAdminAsyncCmd/verifyEventQueueing_r10b.cpp
@@ -122,6 +122,8 @@ VerifyEventQueueing_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminAsyncCmd/verifyMasking_r10b.cpp
+++ b/GrpAdminAsyncCmd/verifyMasking_r10b.cpp
@@ -131,6 +131,8 @@ VerifyMasking_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 
@@ -196,6 +198,8 @@ VerifyMasking_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminAsyncCmd/verifyMaxEvents_r10b.cpp
+++ b/GrpAdminAsyncCmd/verifyMaxEvents_r10b.cpp
@@ -127,6 +127,8 @@ VerifyMaxEvents_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOCQCmd/createResources_r10b.cpp
+++ b/GrpAdminCreateIOCQCmd/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminCreateIOCQCmd/invalidQID_r10b.cpp
+++ b/GrpAdminCreateIOCQCmd/invalidQID_r10b.cpp
@@ -110,6 +110,8 @@ InvalidQID_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOCQCmd/maxQSizeExceed_r10b.cpp
+++ b/GrpAdminCreateIOCQCmd/maxQSizeExceed_r10b.cpp
@@ -119,6 +119,8 @@ MaxQSizeExceed_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOQCmd/prpGreaterPageContig_r10b.cpp
+++ b/GrpAdminCreateIOQCmd/prpGreaterPageContig_r10b.cpp
@@ -158,6 +158,8 @@ PRPGreaterPageContig_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOQCmd/prpGreaterPageDiscontig_r10b.cpp
+++ b/GrpAdminCreateIOQCmd/prpGreaterPageDiscontig_r10b.cpp
@@ -163,6 +163,8 @@ PRPGreaterPageDiscontig_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOQCmd/prpLessPageContig_r10b.cpp
+++ b/GrpAdminCreateIOQCmd/prpLessPageContig_r10b.cpp
@@ -158,6 +158,8 @@ PRPLessPageContig_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOQCmd/prpLessPageDiscontig_r10b.cpp
+++ b/GrpAdminCreateIOQCmd/prpLessPageDiscontig_r10b.cpp
@@ -163,6 +163,8 @@ PRPLessPageDiscontig_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOQCmd/prpSinglePageContig_r10b.cpp
+++ b/GrpAdminCreateIOQCmd/prpSinglePageContig_r10b.cpp
@@ -158,6 +158,8 @@ PRPSinglePageContig_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOQCmd/prpSinglePageDiscontig_r10b.cpp
+++ b/GrpAdminCreateIOQCmd/prpSinglePageDiscontig_r10b.cpp
@@ -163,6 +163,8 @@ PRPSinglePageDiscontig_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOSQCmd/acceptQPriority_r10b.cpp
+++ b/GrpAdminCreateIOSQCmd/acceptQPriority_r10b.cpp
@@ -112,6 +112,8 @@ AcceptQPriority_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminCreateIOSQCmd/createResources_r10b.cpp
+++ b/GrpAdminCreateIOSQCmd/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminCreateIOSQCmd/invalidQID_r10b.cpp
+++ b/GrpAdminCreateIOSQCmd/invalidQID_r10b.cpp
@@ -112,6 +112,8 @@ InvalidQID_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminDeleteIOCQCmd/createResources_r10b.cpp
+++ b/GrpAdminDeleteIOCQCmd/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminDeleteIOCQCmd/deleteAllAtOnce_r10b.cpp
+++ b/GrpAdminDeleteIOCQCmd/deleteAllAtOnce_r10b.cpp
@@ -113,6 +113,8 @@ DeleteAllAtOnce_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminDeleteIOCQCmd/deleteFullQ_r10b.cpp
+++ b/GrpAdminDeleteIOCQCmd/deleteFullQ_r10b.cpp
@@ -128,6 +128,8 @@ DeleteFullQ_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminDeleteIOCQCmd/invalidQID_r10b.cpp
+++ b/GrpAdminDeleteIOCQCmd/invalidQID_r10b.cpp
@@ -114,6 +114,8 @@ InvalidQID_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminDeleteIOSQCmd/createResources_r10b.cpp
+++ b/GrpAdminDeleteIOSQCmd/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminDeleteIOSQCmd/invalidQID_r10b.cpp
+++ b/GrpAdminDeleteIOSQCmd/invalidQID_r10b.cpp
@@ -115,6 +115,8 @@ InvalidQID_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminGetFeatCmd/createResources_r10b.cpp
+++ b/GrpAdminGetFeatCmd/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminGetLogPgCmd/createResources_r10b.cpp
+++ b/GrpAdminGetLogPgCmd/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminIdentifyCmd/createResources_r10b.cpp
+++ b/GrpAdminIdentifyCmd/createResources_r10b.cpp
@@ -106,6 +106,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminNamespaceManagement/unsupportRsvdFields_r10b.cpp
+++ b/GrpAdminNamespaceManagement/unsupportRsvdFields_r10b.cpp
@@ -121,6 +121,8 @@ UnsupportRsvdFields_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpAdminSetFeatCmd/invalidFieldInCmd_r10b.cpp
+++ b/GrpAdminSetFeatCmd/invalidFieldInCmd_r10b.cpp
@@ -103,6 +103,8 @@ InvalidFieldInCmd_r10b::RunCoreTest()
     SharedASQPtr asq = SharedASQPtr(new ASQ(gDutFd));
     asq->Init(5);
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetFeatCmd/invalidFieldInCmd_r12.cpp
+++ b/GrpAdminSetFeatCmd/invalidFieldInCmd_r12.cpp
@@ -103,6 +103,8 @@ InvalidFieldInCmd_r12::RunCoreTest()
     SharedASQPtr asq = SharedASQPtr(new ASQ(gDutFd));
     asq->Init(5);
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidArbitration_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidArbitration_r10b.cpp
@@ -120,6 +120,8 @@ FIDArbitration_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidAsyncEventCfg_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidAsyncEventCfg_r10b.cpp
@@ -117,6 +117,8 @@ FIDAsyncEventCfg_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidIRQCoalescing_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidIRQCoalescing_r10b.cpp
@@ -117,6 +117,8 @@ FIDIRQCoalescing_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidIRQVec_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidIRQVec_r10b.cpp
@@ -117,6 +117,8 @@ FIDIRQVec_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidIRQVec_r11.cpp
+++ b/GrpAdminSetGetFeatCombo/fidIRQVec_r11.cpp
@@ -153,6 +153,8 @@ FIDIRQVec_r11::RunCoreTest()
     }
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE, "Failed to enable controller");
 

--- a/GrpAdminSetGetFeatCombo/fidPwrMgmt_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidPwrMgmt_r10b.cpp
@@ -117,6 +117,8 @@ FIDPwrMgmt_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidTempThres_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidTempThres_r10b.cpp
@@ -117,6 +117,8 @@ FIDTempThres_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidVolatileCash_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidVolatileCash_r10b.cpp
@@ -123,6 +123,8 @@ FIDVolatileCash_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/fidWriteAtomicity_r10b.cpp
+++ b/GrpAdminSetGetFeatCombo/fidWriteAtomicity_r10b.cpp
@@ -117,6 +117,8 @@ FIDWriteAtomicity_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpAdminSetGetFeatCombo/grpAdminSetGetFeatCombo.cpp
+++ b/GrpAdminSetGetFeatCombo/grpAdminSetGetFeatCombo.cpp
@@ -125,6 +125,8 @@ GrpAdminSetGetFeatCombo::SaveState()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 
@@ -162,6 +164,8 @@ GrpAdminSetGetFeatCombo::RestoreState()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpBasicInit/createACQASQ_r10b.cpp
+++ b/GrpBasicInit/createACQASQ_r10b.cpp
@@ -106,6 +106,8 @@ CreateACQASQ_r10b::RunCoreTest()
     asq->Init(5);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpBasicInit/createIOQContigIrq_r10b.cpp
+++ b/GrpBasicInit/createIOQContigIrq_r10b.cpp
@@ -140,6 +140,8 @@ CreateIOQContigIrq_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpCtrlRegisters/ctrlrResetDefaults_r10b.cpp
+++ b/GrpCtrlRegisters/ctrlrResetDefaults_r10b.cpp
@@ -114,6 +114,8 @@ CtrlrResetDefaults_r10b::VerifyCtrlrResetDefaults()
     asq->Init(5);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpGeneralCmds/cidAcceptedIOSQ_r10b.cpp
+++ b/GrpGeneralCmds/cidAcceptedIOSQ_r10b.cpp
@@ -113,6 +113,8 @@ CIDAcceptedIOSQ_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(2);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpGeneralCmds/createResources_r10b.cpp
+++ b/GrpGeneralCmds/createResources_r10b.cpp
@@ -110,6 +110,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(2);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpInterrupts/createResources_r10b.cpp
+++ b/GrpInterrupts/createResources_r10b.cpp
@@ -104,6 +104,8 @@ CreateResources_r10b::RunCoreTest()
     asq->Init(5);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpInterrupts/invalidMSIXIRQ_r10b.cpp
+++ b/GrpInterrupts/invalidMSIXIRQ_r10b.cpp
@@ -122,6 +122,8 @@ InvalidMSIXIRQ_r10b::RunCoreTest()
     }
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpInterrupts/maxIOQMSIX1To1_r10b.cpp
+++ b/GrpInterrupts/maxIOQMSIX1To1_r10b.cpp
@@ -130,6 +130,8 @@ MaxIOQMSIX1To1_r10b::RunCoreTest()
     }
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpInterrupts/maxIOQMSIXManyTo1_r10b.cpp
+++ b/GrpInterrupts/maxIOQMSIXManyTo1_r10b.cpp
@@ -122,6 +122,8 @@ MaxIOQMSIXManyTo1_r10b::RunCoreTest()
             "Unable to use %d IRQ's, but DUT reports it supports", numIrqs);
     }
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpInterrupts/partialReapMSIX_r10b.cpp
+++ b/GrpInterrupts/partialReapMSIX_r10b.cpp
@@ -140,6 +140,8 @@ PartialReapMSIX_r10b::RunCoreTest()
             "Unable to use %d IRQ's, but DUT reports it supports", numIrqs);
     }
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMDatasetMgmtCmd/createResources_r10b.cpp
+++ b/GrpNVMDatasetMgmtCmd/createResources_r10b.cpp
@@ -117,6 +117,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMFlushCmd/createResources_r10b.cpp
+++ b/GrpNVMFlushCmd/createResources_r10b.cpp
@@ -112,6 +112,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMFlushCmd/functionalityMeta_r10b.cpp
+++ b/GrpNVMFlushCmd/functionalityMeta_r10b.cpp
@@ -154,6 +154,8 @@ FunctionalityMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpNVMReadCmd/createResources_r10b.cpp
+++ b/GrpNVMReadCmd/createResources_r10b.cpp
@@ -112,6 +112,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMReadCmd/lbaOutOfRangeMeta_r10b.cpp
+++ b/GrpNVMReadCmd/lbaOutOfRangeMeta_r10b.cpp
@@ -130,6 +130,8 @@ LBAOutOfRangeMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpNVMReadCmd/lbaOutOfRangeMeta_r12.cpp
+++ b/GrpNVMReadCmd/lbaOutOfRangeMeta_r12.cpp
@@ -132,6 +132,8 @@ LBAOutOfRangeMeta_r12::RunCoreTest()
             IRQ::SetAnySchemeSpecifyNum(1);
 
             gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+            gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+            gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
             if (gCtrlrConfig->SetState(ST_ENABLE) == false)
                 throw FrmwkEx(HERE);
 

--- a/GrpNVMReadCmd/protInfoIgnoreMeta_r10b.cpp
+++ b/GrpNVMReadCmd/protInfoIgnoreMeta_r10b.cpp
@@ -120,6 +120,8 @@ ProtInfoIgnoreMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpNVMReadCmd/protInfoIgnoreMeta_r12.cpp
+++ b/GrpNVMReadCmd/protInfoIgnoreMeta_r12.cpp
@@ -124,6 +124,8 @@ ProtInfoIgnoreMeta_r12::RunCoreTest()
             IRQ::SetAnySchemeSpecifyNum(1);
 
             gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+            gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+            gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
             if (gCtrlrConfig->SetState(ST_ENABLE) == false)
                 throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteCmd/createResources_r10b.cpp
+++ b/GrpNVMWriteCmd/createResources_r10b.cpp
@@ -113,6 +113,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteCmd/lbaOutOfRangeMeta_r10b.cpp
+++ b/GrpNVMWriteCmd/lbaOutOfRangeMeta_r10b.cpp
@@ -129,6 +129,8 @@ LBAOutOfRangeMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteCmd/lbaOutOfRangeMeta_r12.cpp
+++ b/GrpNVMWriteCmd/lbaOutOfRangeMeta_r12.cpp
@@ -132,6 +132,8 @@ LBAOutOfRangeMeta_r12::RunCoreTest()
             IRQ::SetAnySchemeSpecifyNum(1);
 
             gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+            gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+            gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
             if (gCtrlrConfig->SetState(ST_ENABLE) == false)
                 throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteCmd/protInfoIgnoreMeta_r10b.cpp
+++ b/GrpNVMWriteCmd/protInfoIgnoreMeta_r10b.cpp
@@ -119,6 +119,8 @@ ProtInfoIgnoreMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteCmd/protInfoIgnoreMeta_r12.cpp
+++ b/GrpNVMWriteCmd/protInfoIgnoreMeta_r12.cpp
@@ -123,6 +123,8 @@ ProtInfoIgnoreMeta_r12::RunCoreTest()
             IRQ::SetAnySchemeSpecifyNum(1);
 
             gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+            gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+            gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
             if (gCtrlrConfig->SetState(ST_ENABLE) == false)
                 throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/createResources_r10b.cpp
+++ b/GrpNVMWriteReadCombo/createResources_r10b.cpp
@@ -108,6 +108,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/nlbaMeta_r10b.cpp
+++ b/GrpNVMWriteReadCombo/nlbaMeta_r10b.cpp
@@ -154,6 +154,8 @@ NLBAMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/prp2Rsvd_r10b.cpp
+++ b/GrpNVMWriteReadCombo/prp2Rsvd_r10b.cpp
@@ -128,6 +128,8 @@ PRP2Rsvd_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(2);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/prpOffsetDualPgMultiBlk_r10b.cpp
+++ b/GrpNVMWriteReadCombo/prpOffsetDualPgMultiBlk_r10b.cpp
@@ -119,6 +119,8 @@ PRPOffsetDualPgMultiBlk_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(2);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/prpOffsetMultiPgMultiBlk_r10b.cpp
+++ b/GrpNVMWriteReadCombo/prpOffsetMultiPgMultiBlk_r10b.cpp
@@ -119,6 +119,8 @@ PRPOffsetMultiPgMultiBlk_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(2);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/prpOffsetSinglePgMultiBlk_r10b.cpp
+++ b/GrpNVMWriteReadCombo/prpOffsetSinglePgMultiBlk_r10b.cpp
@@ -119,6 +119,8 @@ PRPOffsetSinglePgMultiBlk_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(2);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpNVMWriteReadCombo/startingLBAMeta_r10b.cpp
+++ b/GrpNVMWriteReadCombo/startingLBAMeta_r10b.cpp
@@ -151,6 +151,8 @@ StartingLBAMeta_r10b::RunCoreTest()
         IRQ::SetAnySchemeSpecifyNum(1);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpQueues/adminQFull_r10b.cpp
+++ b/GrpQueues/adminQFull_r10b.cpp
@@ -136,6 +136,8 @@ AdminQFull_r10b::AdminQFull(uint16_t numASQEntries, uint16_t numACQEntries,
     asq->Init(numASQEntries);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpQueues/adminQRollChkDiff_r10b.cpp
+++ b/GrpQueues/adminQRollChkDiff_r10b.cpp
@@ -118,6 +118,8 @@ AdminQRollChkDiff_r10b::RunCoreTest()
         asq->Init(mASQSize);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpQueues/adminQRollChkSame_r10b.cpp
+++ b/GrpQueues/adminQRollChkSame_r10b.cpp
@@ -114,6 +114,8 @@ AdminQRollChkSame_r10b::RunCoreTest()
         asq->Init(adminQSize);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpQueues/createResources_r10b.cpp
+++ b/GrpQueues/createResources_r10b.cpp
@@ -107,6 +107,8 @@ CreateResources_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpQueues/illegalCreateOrder_r10b.cpp
+++ b/GrpQueues/illegalCreateOrder_r10b.cpp
@@ -102,6 +102,8 @@ IllegalCreateOrder_r10b::RunCoreTest()
     asq->Init(5);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpQueues/initialStateAdmin_r10b.cpp
+++ b/GrpQueues/initialStateAdmin_r10b.cpp
@@ -116,6 +116,8 @@ InitialStateAdmin_r10b::ValidateInitialStateAdmin(SharedACQPtr acq,
     for (uint16_t i = 0; i < 2; i++) {
         LOG_NRM("Validating initial state admin for #%d times", i);
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpReservationsHostA/createResources_r11.cpp
+++ b/GrpReservationsHostA/createResources_r11.cpp
@@ -118,6 +118,8 @@ CreateResources_r11::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpReservationsHostA/unsupportRsvdFields_r10b.cpp
+++ b/GrpReservationsHostA/unsupportRsvdFields_r10b.cpp
@@ -121,6 +121,8 @@ UnsupportRsvdFields_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpReservationsHostB/createResources_r11.cpp
+++ b/GrpReservationsHostB/createResources_r11.cpp
@@ -118,6 +118,8 @@ CreateResources_r11::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/GrpReservationsHostB/unsupportRsvdFields_r10b.cpp
+++ b/GrpReservationsHostB/unsupportRsvdFields_r10b.cpp
@@ -121,6 +121,8 @@ UnsupportRsvdFields_r10b::RunCoreTest()
     IRQ::SetAnySchemeSpecifyNum(1);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 }

--- a/GrpResets/ctrlrResetIOQDeleted_r10b.cpp
+++ b/GrpResets/ctrlrResetIOQDeleted_r10b.cpp
@@ -142,6 +142,8 @@ CtrlrResetIOQDeleted_r10b::VerifyCtrlrResetDeletesIOQs(SharedACQPtr acq,
         snprintf(work, sizeof(work), "iter%d", i);
 
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/GrpResets/ctrlrResetNotEffectAdminQ_r10b.cpp
+++ b/GrpResets/ctrlrResetNotEffectAdminQ_r10b.cpp
@@ -105,6 +105,8 @@ CtrlrResetNotEffectAdminQ_r10b::RunCoreTest()
     asq->Init(15);
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 
@@ -114,6 +116,8 @@ CtrlrResetNotEffectAdminQ_r10b::RunCoreTest()
     if (gCtrlrConfig->SetState(ST_DISABLE) == false)
         throw FrmwkEx(HERE);
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE);
 

--- a/Singletons/ctrlrConfig.cpp
+++ b/Singletons/ctrlrConfig.cpp
@@ -22,6 +22,8 @@ const uint16_t CtrlrConfig::MAX_MSI_SINGLE_IRQ_VEC = 0;
 const uint16_t CtrlrConfig::MAX_MSI_MULTI_IRQ_VEC = 31;
 const uint16_t CtrlrConfig::MAX_MSIX_IRQ_VEC = 2047;
 const uint8_t CtrlrConfig::CSS_NVM_CMDSET   = 0x00;
+const uint8_t CtrlrConfig::MIN_IOCQES = 4;
+const uint8_t CtrlrConfig::MIN_IOSQES = 6;
 
 
 bool CtrlrConfig::mInstanceFlag = false;

--- a/Singletons/ctrlrConfig.h
+++ b/Singletons/ctrlrConfig.h
@@ -52,6 +52,9 @@ public:
     static const uint16_t MAX_MSI_MULTI_IRQ_VEC;
     static const uint16_t MAX_MSIX_IRQ_VEC;
 
+    static const uint8_t MIN_IOCQES;
+    static const uint8_t MIN_IOSQES;
+
     /**
      * Gets the active IRQ scheme enabled in the device. It doesn't
      * indicate that IRQ's are being used, to use IRQ's CQ's must be created

--- a/Singletons/informative.cpp
+++ b/Singletons/informative.cpp
@@ -425,6 +425,8 @@ Informative::Init()
         SharedASQPtr asq = SharedASQPtr(new ASQ(gDutFd));
         asq->Init(2);
         gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+        gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+        gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
         if (gCtrlrConfig->SetState(ST_ENABLE) == false)
             throw FrmwkEx(HERE);
 

--- a/Utils/queues.cpp
+++ b/Utils/queues.cpp
@@ -292,6 +292,8 @@ Queues::BasicAdminQueueSetup(SharedACQPtr &acq, SharedASQPtr &asq,
     IRQ::SetAnySchemeSpecifyNum(1);     // throws upon error
 
     gCtrlrConfig->SetCSS(CtrlrConfig::CSS_NVM_CMDSET);
+    gCtrlrConfig->SetIOCQES(CtrlrConfig::MIN_IOCQES);
+    gCtrlrConfig->SetIOSQES(CtrlrConfig::MIN_IOSQES);
     if (gCtrlrConfig->SetState(ST_ENABLE) == false)
         throw FrmwkEx(HERE, "Failed to enable the controller");
 }


### PR DESCRIPTION
Specification requires that CC.IOCQES and CC.IOSQES are
configured prior to device enbale using CC.EN. Invalid value
will lead to failure to initialize device.

When device properly implements Controller Reset, hence clearing of
CC,  this will lead to unexpected test failures.

The following change adds default minimal values prior to
enabling the device. Values are taken from specification
and same approach is used in nvme driver in the linux kernel.

Signed-off-by: Shimi Gersner <gersner@gmail.com>